### PR TITLE
feat(signaling): add Socket.IO gateway with JWT handshake auth

### DIFF
--- a/docs/signaling-events.md
+++ b/docs/signaling-events.md
@@ -1,0 +1,66 @@
+# Signaling Events
+
+Documentation for the Socket.IO signaling gateway.
+
+## Connection
+
+The gateway is available on the default Socket.IO namespace (`/`). Clients must authenticate at the handshake layer — **no messages are processed from unauthenticated sockets.**
+
+### Authentication
+
+Pass a valid JWT access token in **one** of the following ways:
+
+#### Option A — Recommended: `auth` option
+
+```js
+import { io } from 'socket.io-client';
+
+const socket = io('http://localhost:3000', {
+  auth: {
+    token: '<access_token>',
+  },
+});
+```
+
+#### Option B — Fallback: `Authorization` header
+
+```js
+const socket = io('http://localhost:3000', {
+  extraHeaders: {
+    Authorization: 'Bearer <access_token>',
+  },
+});
+```
+
+---
+
+## Lifecycle Events
+
+### Server → Client
+
+| Event   | Payload                             | Description                                                           |
+| ------- | ----------------------------------- | --------------------------------------------------------------------- |
+| `error` | `{ code: number, message: string }` | Emitted before disconnect when authentication fails. `code` is `401`. |
+
+### Server-side Lifecycle
+
+| Hook               | Behaviour                                                                           |
+| ------------------ | ----------------------------------------------------------------------------------- |
+| `handleConnection` | Validates JWT, loads user from DB, sets `socket.data.user`. Disconnects on failure. |
+| `handleDisconnect` | Logs disconnect with `socketId` and `userId`.                                       |
+
+---
+
+## `socket.data.user`
+
+After a successful handshake, `socket.data.user` is populated with the Prisma `User` object (excluding `passwordHash`).
+
+---
+
+## Out of Scope (this issue)
+
+- WebRTC offer/answer/ICE relay
+- Room or meeting management
+- Presence broadcasting
+
+These will be implemented in subsequent issues.

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { HealthModule } from './health/health.modules';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
 import { MeetingsModule } from './meetings/meetings.module';
+import { SignalingModule } from './signaling/signaling.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { MeetingsModule } from './meetings/meetings.module';
     UsersModule,
     AuthModule,
     MeetingsModule,
+    SignalingModule,
   ],
 })
 export class AppModule {}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -20,22 +20,13 @@ import { UsersModule } from '../users/users.module';
       useFactory: (configService: ConfigService) => {
         const secret = configService.get<string>('ACCESS_TOKEN_SECRET');
         const expiresIn = configService.get<string>('ACCESS_TOKEN_EXPIRES_IN') || '15m';
-
-        if (!secret) {
-          throw new Error('ACCESS_TOKEN_SECRET is not defined');
-        }
-
-        return {
-          secret,
-          signOptions: {
-            expiresIn,
-          } as SignOptions,
-        };
+        if (!secret) throw new Error('ACCESS_TOKEN_SECRET is not defined');
+        return { secret, signOptions: { expiresIn } as SignOptions };
       },
     }),
   ],
   controllers: [AuthController],
   providers: [AuthService, RefreshTokenService, RefreshTokenRepository, JwtStrategy],
-  exports: [AuthService, JwtStrategy, PassportModule],
+  exports: [AuthService, JwtStrategy, PassportModule, JwtModule],
 })
 export class AuthModule {}

--- a/src/signaling/signaling.gateway.ts
+++ b/src/signaling/signaling.gateway.ts
@@ -1,0 +1,85 @@
+import {
+  WebSocketGateway,
+  WebSocketServer,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+} from '@nestjs/websockets';
+import { Logger, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { Server, Socket } from 'socket.io';
+import { User } from '@prisma/client';
+
+interface SocketData {
+  user?: User;
+}
+
+type AuthenticatedSocket = Socket<
+  Record<string, never>,
+  Record<string, never>,
+  Record<string, never>,
+  SocketData
+>;
+import { UsersRepository } from '../users/users.repository';
+import { JwtPayload } from '../auth/interfaces/jwt-payload.interface';
+
+@WebSocketGateway({
+  cors: {
+    origin: 'http://localhost:5173',
+    credentials: true,
+  },
+})
+export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnect {
+  @WebSocketServer()
+  server!: Server;
+
+  private readonly logger = new Logger(SignalingGateway.name);
+
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly usersRepository: UsersRepository,
+  ) {}
+
+  async handleConnection(socket: AuthenticatedSocket): Promise<void> {
+    try {
+      const token = this.extractToken(socket);
+
+      if (!token) {
+        throw new UnauthorizedException('Missing authentication token');
+      }
+
+      const payload = this.jwtService.verify<JwtPayload>(token);
+      const user = await this.usersRepository.findById(payload.userId);
+
+      if (!user) {
+        throw new UnauthorizedException('User not found');
+      }
+
+      socket.data.user = user;
+      this.logger.log(`Client connected: socketId=${socket.id} userId=${user.id}`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unauthorized';
+      this.logger.warn(`Connection rejected: socketId=${socket.id} reason=${message}`);
+      socket.emit('error', { code: 401, message });
+      socket.disconnect(true);
+    }
+  }
+
+  handleDisconnect(socket: AuthenticatedSocket): void {
+    const userId: string | undefined = socket.data.user?.id;
+    this.logger.log(
+      `Client disconnected: socketId=${socket.id} userId=${userId ?? 'unauthenticated'}`,
+    );
+  }
+
+  private extractToken(socket: AuthenticatedSocket): string | undefined {
+    const authToken = socket.handshake.auth?.token as string | undefined;
+    if (authToken) return authToken;
+
+    const authHeader = socket.handshake.headers?.authorization;
+    if (authHeader?.startsWith('Bearer ')) {
+      return authHeader.slice(7);
+    }
+
+    return undefined;
+  }
+}

--- a/src/signaling/signaling.gateway.ts
+++ b/src/signaling/signaling.gateway.ts
@@ -13,9 +13,13 @@ interface SocketData {
   user?: User;
 }
 
+interface ServerToClientEvents {
+  error: (data: { code: number; message: string }) => void;
+}
+
 type AuthenticatedSocket = Socket<
   Record<string, never>,
-  Record<string, never>,
+  ServerToClientEvents,
   Record<string, never>,
   SocketData
 >;

--- a/src/signaling/signaling.module.ts
+++ b/src/signaling/signaling.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { SignalingGateway } from './signaling.gateway';
+import { AuthModule } from '../auth/auth.module';
+import { UsersModule } from '../users/users.module';
+
+@Module({
+  imports: [AuthModule, UsersModule],
+  providers: [SignalingGateway],
+})
+export class SignalingModule {}


### PR DESCRIPTION
## References
- Closes #8 (WM-1)

## Description
- Add `SignalingGateway` implementing `OnGatewayConnection` and `OnGatewayDisconnect` via `@nestjs/platform-socket.io`
- Authenticate at the Socket.IO handshake layer using `JwtService.verify()` — no unauthenticated sockets are accepted
- Extract JWT from `socket.handshake.auth.token` (preferred) or `Authorization: Bearer` header (fallback)
- Attach the verified Prisma `User` to `socket.data.user` on successful connection
- Emit `{ code: 401, message }` error event and disconnect immediately on auth failure
- Log connect/disconnect lifecycle events with `socketId` and `userId`
- Export `JwtModule` from `AuthModule` so `JwtService` is injectable in `SignalingModule`
- Register `SignalingModule` (imports `AuthModule` + `UsersModule`) in `AppModule`
- Add `docs/signaling-events.md` documenting handshake auth format and lifecycle hooks

## Test plan
- [ ] Client connecting with a valid JWT is accepted; `socket.data.user` is populated
- [ ] Client connecting without a token receives an `error` event with code 401 and is disconnected
- [ ] Client connecting with an expired or invalid token is disconnected immediately
- [ ] Connect and disconnect events are logged with `socketId` and `userId`
