### PR TITLE
feat(signaling): add WebRTC relay for offer, answer, ice-candidate

### DIFF
--- a/.github/plans/WM-4.md
+++ b/.github/plans/WM-4.md
@@ -1,0 +1,128 @@
+# WM-4: WebRTC Signaling Relay in Socket.IO Gateway
+
+## 1. Feature Summary
+
+This feature adds three Socket.IO event handlers to SignalingGateway -- webrtc-offer, webrtc-answer, and webrtc-ice-candidate -- that transparently relay WebRTC negotiation messages from a sender socket to a target socket within the same meeting room. The server validates room membership for both parties but never parses, logs, or stores the SDP or ICE candidate content.
+
+---
+
+## 2. Problem Statement
+
+WebRTC peer connections require an out-of-band signaling channel to exchange session descriptions (offer/answer) and ICE candidates before a direct media channel can be opened. Without a relay mechanism in the gateway, participants have no way to negotiate their peer connections after joining a meeting room. This is the missing link between presence management (WM-2) and live media.
+
+---
+
+## 3. Technical Design
+
+### Affected Modules
+
+- src/signaling/signaling.gateway.ts -- add three @SubscribeMessage handlers and a shared private relay helper; extend ClientToServerEvents and ServerToClientEvents interfaces
+- src/signaling/signaling.gateway.spec.ts -- add unit tests for relay events and error paths
+- docs/signaling-events.md -- document new events, payload schemas, and error codes
+
+### Services to Modify or Create
+
+SignalingGateway -- add the following:
+
+New interfaces: WebRtcRelayPayload { meetingId, targetSocketId, payload: unknown } and WebRtcRelayServerPayload { fromSocketId, payload: unknown }.
+
+Extend ClientToServerEvents with webrtc-offer, webrtc-answer, webrtc-ice-candidate (each taking WebRtcRelayPayload).
+Extend ServerToClientEvents with webrtc-offer, webrtc-answer, webrtc-ice-candidate (each delivering WebRtcRelayServerPayload).
+
+Add private handleWebRtcRelay(event, payload, socket) implementing:
+
+- Auth guard: emit error 401 if socket.data.user absent
+- Input validation: emit error 400 if meetingId or targetSocketId missing/non-string
+- Sender-presence check: emit error 403 if sender not in room
+- Target-presence check: emit error 404 if target not in room
+
+### Database Changes
+
+None. All validation relies on the in-memory rooms map populated by join-room.
+
+### API Endpoints (WebSocket Events)
+
+Client-to-server: webrtc-offer, webrtc-answer, webrtc-ice-candidate
+Payload: { meetingId: string; targetSocketId: string; payload: unknown }
+
+Server-to-client (relayed to target): webrtc-offer, webrtc-answer, webrtc-ice-candidate
+Payload: { fromSocketId: string; payload: unknown }
+
+Error codes emitted to sender: 400 (bad input), 401 (unauthenticated), 403 (sender not in room), 404 (target not in room)
+
+### Validation Rules
+
+- meetingId: required non-empty string
+- targetSocketId: required non-empty string
+
+---
+
+## 4. Edge Cases
+
+1. Sender not authenticated -- emit error 401.
+2. Missing meetingId or targetSocketId -- emit error 400.
+3. Sender not in room -- emit error 403.
+4. Target not in room (left or never joined) -- emit error 404.
+5. Sender targets itself -- both presence checks pass; event delivered back to sender. Valid for loopback; do not block.
+6. Relay before join-room -- caught by sender-presence check (403).
+7. Target disconnects between validation and emit -- Socket.IO silently drops; no error needed.
+8. Malformed meetingId (null/non-string) -- caught by input validation (400).
+9. payload.payload is null or undefined -- forward as-is without inspection.
+
+---
+
+## 5. Implementation Plan
+
+### Step 1: Add payload interfaces
+
+Add WebRtcRelayPayload and WebRtcRelayServerPayload interfaces to signaling.gateway.ts alongside existing payload interfaces.
+
+### Step 2: Extend event type interfaces
+
+Add webrtc-offer, webrtc-answer, webrtc-ice-candidate to ClientToServerEvents and ServerToClientEvents.
+
+### Step 3: Implement handleWebRtcRelay helper
+
+Private method with full validation (401, 400, 403, 404) and server.to(targetSocketId).emit() forwarding. Log event/meetingId/fromSocketId/targetSocketId only.
+
+### Step 4: Add three @SubscribeMessage handlers
+
+Add handleWebRtcOffer, handleWebRtcAnswer, handleWebRtcIceCandidate each delegating to handleWebRtcRelay.
+
+## 6. Implementation Order
+
+1. Add WebRtcRelayPayload and WebRtcRelayServerPayload interfaces
+2. Extend ClientToServerEvents with three new client-to-server events
+3. Extend ServerToClientEvents with three new server-to-client events
+4. Implement private handleWebRtcRelay with full validation and forwarding
+5. Add @SubscribeMessage('webrtc-offer') handler
+6. Add @SubscribeMessage('webrtc-answer') handler
+7. Add @SubscribeMessage('webrtc-ice-candidate') handler
+8. Write unit tests in signaling.gateway.spec.ts
+9. Update docs/signaling-events.md
+10. Run pnpm lint and pnpm test
+
+---
+
+## 7. Task Breakdown
+
+- [ ] Add WebRtcRelayPayload interface: { meetingId: string; targetSocketId: string; payload: unknown }
+- [ ] Add WebRtcRelayServerPayload interface: { fromSocketId: string; payload: unknown }
+- [ ] Extend ClientToServerEvents with webrtc-offer, webrtc-answer, webrtc-ice-candidate
+- [ ] Extend ServerToClientEvents with webrtc-offer, webrtc-answer, webrtc-ice-candidate
+- [ ] Implement private handleWebRtcRelay with auth guard, input validation, sender-presence (403), target-presence (404), and server.to(targetSocketId).emit()
+- [ ] Ensure handleWebRtcRelay never logs payload.payload contents
+- [ ] Add @SubscribeMessage('webrtc-offer') handler delegating to handleWebRtcRelay
+- [ ] Add @SubscribeMessage('webrtc-answer') handler delegating to handleWebRtcRelay
+- [ ] Add @SubscribeMessage('webrtc-ice-candidate') handler delegating to handleWebRtcRelay
+- [ ] Test: successful webrtc-offer relay — target socket receives event with fromSocketId and payload
+- [ ] Test: successful webrtc-answer relay
+- [ ] Test: successful webrtc-ice-candidate relay
+- [ ] Test: unauthenticated sender returns error { code: 401 }
+- [ ] Test: missing meetingId returns error { code: 400 }
+- [ ] Test: missing targetSocketId returns error { code: 400 }
+- [ ] Test: sender not in room returns error { code: 403 }
+- [ ] Test: target not in room returns error { code: 404 }
+- [ ] Update docs/signaling-events.md with relay event table and payload schemas
+- [ ] Run pnpm lint and confirm clean
+- [ ] Run pnpm test and confirm all tests pass

--- a/docs/signaling-events.md
+++ b/docs/signaling-events.md
@@ -131,7 +131,55 @@ socket.emit('leave-room', { meetingId: 'meeting-uuid' });
 
 ---
 
+## WebRTC Signaling Relay
+
+Authenticated participants who are joined to a meeting room can relay WebRTC negotiation messages to a specific peer. The server forwards the message transparently — it never parses, logs, or stores SDP or ICE candidate content.
+
+### Client → Server Events
+
+| Event                  | Payload                                                           | Description                                |
+| ---------------------- | ----------------------------------------------------------------- | ------------------------------------------ |
+| `webrtc-offer`         | `{ meetingId: string, targetSocketId: string, payload: unknown }` | Relay a WebRTC offer to the target peer.   |
+| `webrtc-answer`        | `{ meetingId: string, targetSocketId: string, payload: unknown }` | Relay a WebRTC answer to the target peer.  |
+| `webrtc-ice-candidate` | `{ meetingId: string, targetSocketId: string, payload: unknown }` | Relay an ICE candidate to the target peer. |
+
+### Server → Client Events (relayed to target)
+
+| Event                  | Payload                                      | Description                              |
+| ---------------------- | -------------------------------------------- | ---------------------------------------- |
+| `webrtc-offer`         | `{ fromSocketId: string, payload: unknown }` | Forwarded offer from a peer.             |
+| `webrtc-answer`        | `{ fromSocketId: string, payload: unknown }` | Forwarded answer from a peer.            |
+| `webrtc-ice-candidate` | `{ fromSocketId: string, payload: unknown }` | Forwarded ICE candidate from a peer.     |
+| `error`                | `{ code: number, message: string }`          | Emitted to sender on validation failure. |
+
+### Error Codes
+
+| Code  | Meaning                                           |
+| ----- | ------------------------------------------------- |
+| `400` | Missing or invalid `meetingId` / `targetSocketId` |
+| `401` | Not authenticated                                 |
+| `403` | Sender is not joined to the specified room        |
+| `404` | Target socket is not in the room                  |
+
+### Example: Sending a WebRTC Offer
+
+```js
+// After both peers have joined the same room...
+socket.emit('webrtc-offer', {
+  meetingId: 'meeting-uuid',
+  targetSocketId: 'target-socket-id',
+  payload: { type: 'offer', sdp: '<sdp-string>' },
+});
+
+// The target peer receives:
+socket.on('webrtc-offer', ({ fromSocketId, payload }) => {
+  console.log(`Offer from ${fromSocketId}`, payload);
+  // createAnswer and relay back via webrtc-answer
+});
+```
+
+---
+
 ## Out of Scope
 
-- WebRTC offer/answer/ICE relay
 - Distributed presence (Redis adapter)

--- a/src/signaling/signaling.gateway.spec.ts
+++ b/src/signaling/signaling.gateway.spec.ts
@@ -322,6 +322,152 @@ describe('SignalingGateway', () => {
     });
   });
 
+  describe('handleWebRtcOffer / handleWebRtcAnswer / handleWebRtcIceCandidate', () => {
+    const meetingId = 'meeting-1';
+    const targetSocketId = 'socket-target';
+
+    async function setupSenderAndTarget() {
+      // Sender joins the room
+      const sender = createMockSocket({ id: 'socket-1' });
+      sender.data.user = fakeUser as never;
+      meetingsRepository.findById.mockResolvedValue({ id: meetingId });
+      meetingsRepository.findMemberByMeetingAndUser.mockResolvedValue({ id: 'member-1' });
+      (sender.to as jest.Mock).mockReturnValue({ emit: jest.fn() });
+      await gateway.handleJoinRoom({ meetingId }, sender);
+
+      // Target joins the room
+      const target = createMockSocket({ id: targetSocketId });
+      target.data.user = fakeUser2 as never;
+      meetingsRepository.findMemberByMeetingAndUser.mockResolvedValue({ id: 'member-2' });
+      (target.to as jest.Mock).mockReturnValue({ emit: jest.fn() });
+      await gateway.handleJoinRoom({ meetingId }, target);
+
+      return { sender, target };
+    }
+
+    it('should relay webrtc-offer to the target socket', async () => {
+      const { sender } = await setupSenderAndTarget();
+
+      const serverEmit = jest.fn();
+      const mockServer = gateway as unknown as { server: { to: jest.Mock } };
+      mockServer.server.to.mockReturnValue({ emit: serverEmit });
+
+      gateway.handleWebRtcOffer(
+        { meetingId, targetSocketId, payload: { sdp: 'REDACTED' } },
+        sender,
+      );
+
+      expect(mockServer.server.to).toHaveBeenCalledWith(targetSocketId);
+      expect(serverEmit).toHaveBeenCalledWith('webrtc-offer', {
+        fromSocketId: 'socket-1',
+        payload: { sdp: 'REDACTED' },
+      });
+    });
+
+    it('should relay webrtc-answer to the target socket', async () => {
+      const { sender } = await setupSenderAndTarget();
+
+      const serverEmit = jest.fn();
+      const mockServer = gateway as unknown as { server: { to: jest.Mock } };
+      mockServer.server.to.mockReturnValue({ emit: serverEmit });
+
+      gateway.handleWebRtcAnswer({ meetingId, targetSocketId, payload: { sdp: 'answer' } }, sender);
+
+      expect(mockServer.server.to).toHaveBeenCalledWith(targetSocketId);
+      expect(serverEmit).toHaveBeenCalledWith('webrtc-answer', {
+        fromSocketId: 'socket-1',
+        payload: { sdp: 'answer' },
+      });
+    });
+
+    it('should relay webrtc-ice-candidate to the target socket', async () => {
+      const { sender } = await setupSenderAndTarget();
+
+      const serverEmit = jest.fn();
+      const mockServer = gateway as unknown as { server: { to: jest.Mock } };
+      mockServer.server.to.mockReturnValue({ emit: serverEmit });
+
+      gateway.handleWebRtcIceCandidate(
+        { meetingId, targetSocketId, payload: { candidate: 'REDACTED' } },
+        sender,
+      );
+
+      expect(mockServer.server.to).toHaveBeenCalledWith(targetSocketId);
+      expect(serverEmit).toHaveBeenCalledWith('webrtc-ice-candidate', {
+        fromSocketId: 'socket-1',
+        payload: { candidate: 'REDACTED' },
+      });
+    });
+
+    it('should emit 401 when sender is not authenticated', () => {
+      const socket = createMockSocket();
+      socket.data.user = undefined;
+
+      gateway.handleWebRtcOffer({ meetingId, targetSocketId, payload: {} }, socket);
+
+      expect(socket.emit).toHaveBeenCalledWith('error', {
+        code: 401,
+        message: 'Not authenticated',
+      });
+    });
+
+    it('should emit 400 when meetingId is missing', () => {
+      const socket = createMockSocket();
+      socket.data.user = fakeUser as never;
+
+      gateway.handleWebRtcOffer({ meetingId: '', targetSocketId, payload: {} }, socket);
+
+      expect(socket.emit).toHaveBeenCalledWith('error', {
+        code: 400,
+        message: 'meetingId and targetSocketId are required',
+      });
+    });
+
+    it('should emit 400 when targetSocketId is missing', () => {
+      const socket = createMockSocket();
+      socket.data.user = fakeUser as never;
+
+      gateway.handleWebRtcOffer({ meetingId, targetSocketId: '', payload: {} }, socket);
+
+      expect(socket.emit).toHaveBeenCalledWith('error', {
+        code: 400,
+        message: 'meetingId and targetSocketId are required',
+      });
+    });
+
+    it('should emit 403 when sender is not in the room', () => {
+      const socket = createMockSocket({ id: 'socket-not-in-room' });
+      socket.data.user = fakeUser as never;
+
+      gateway.handleWebRtcOffer({ meetingId, targetSocketId, payload: {} }, socket);
+
+      expect(socket.emit).toHaveBeenCalledWith('error', {
+        code: 403,
+        message: 'You are not in this room',
+      });
+    });
+
+    it('should emit 404 when target is not in the room', async () => {
+      // Only sender joins
+      const socket = createMockSocket({ id: 'socket-1' });
+      socket.data.user = fakeUser as never;
+      meetingsRepository.findById.mockResolvedValue({ id: meetingId });
+      meetingsRepository.findMemberByMeetingAndUser.mockResolvedValue({ id: 'member-1' });
+      (socket.to as jest.Mock).mockReturnValue({ emit: jest.fn() });
+      await gateway.handleJoinRoom({ meetingId }, socket);
+
+      gateway.handleWebRtcOffer(
+        { meetingId, targetSocketId: 'socket-not-in-room', payload: {} },
+        socket,
+      );
+
+      expect(socket.emit).toHaveBeenCalledWith('error', {
+        code: 404,
+        message: 'Target socket is not in this room',
+      });
+    });
+  });
+
   // ── disconnect cleanup ─────────────────────────────────────────────────
 
   describe('handleDisconnect', () => {

--- a/src/signaling/signaling.gateway.ts
+++ b/src/signaling/signaling.gateway.ts
@@ -34,17 +34,34 @@ interface GetParticipantsPayload {
   meetingId: string;
 }
 
+interface WebRtcRelayPayload {
+  meetingId: string;
+  targetSocketId: string;
+  payload: unknown;
+}
+
+interface WebRtcRelayServerPayload {
+  fromSocketId: string;
+  payload: unknown;
+}
+
 interface ServerToClientEvents {
   error: (data: { code: number; message: string }) => void;
   'participant-joined': (data: { meetingId: string; participant: ParticipantInfo }) => void;
   'participant-left': (data: { meetingId: string; participant: ParticipantInfo }) => void;
   'participants-list': (data: { meetingId: string; participants: ParticipantInfo[] }) => void;
+  'webrtc-offer': (data: WebRtcRelayServerPayload) => void;
+  'webrtc-answer': (data: WebRtcRelayServerPayload) => void;
+  'webrtc-ice-candidate': (data: WebRtcRelayServerPayload) => void;
 }
 
 interface ClientToServerEvents {
   'join-room': (payload: JoinRoomPayload) => void;
   'leave-room': (payload: LeaveRoomPayload) => void;
   'get-participants': (payload: GetParticipantsPayload) => void;
+  'webrtc-offer': (payload: WebRtcRelayPayload) => void;
+  'webrtc-answer': (payload: WebRtcRelayPayload) => void;
+  'webrtc-ice-candidate': (payload: WebRtcRelayPayload) => void;
 }
 
 interface SocketData {
@@ -212,6 +229,71 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
 
     const participants = this.getParticipants(meetingId);
     socket.emit('participants-list', { meetingId, participants });
+  }
+
+  @SubscribeMessage('webrtc-offer')
+  handleWebRtcOffer(
+    @MessageBody() payload: WebRtcRelayPayload,
+    @ConnectedSocket() socket: AuthenticatedSocket,
+  ): void {
+    this.handleWebRtcRelay('webrtc-offer', payload, socket);
+  }
+
+  @SubscribeMessage('webrtc-answer')
+  handleWebRtcAnswer(
+    @MessageBody() payload: WebRtcRelayPayload,
+    @ConnectedSocket() socket: AuthenticatedSocket,
+  ): void {
+    this.handleWebRtcRelay('webrtc-answer', payload, socket);
+  }
+
+  @SubscribeMessage('webrtc-ice-candidate')
+  handleWebRtcIceCandidate(
+    @MessageBody() payload: WebRtcRelayPayload,
+    @ConnectedSocket() socket: AuthenticatedSocket,
+  ): void {
+    this.handleWebRtcRelay('webrtc-ice-candidate', payload, socket);
+  }
+
+  private handleWebRtcRelay(
+    event: 'webrtc-offer' | 'webrtc-answer' | 'webrtc-ice-candidate',
+    payload: WebRtcRelayPayload,
+    socket: AuthenticatedSocket,
+  ): void {
+    if (!socket.data.user) {
+      socket.emit('error', { code: 401, message: 'Not authenticated' });
+      return;
+    }
+
+    if (
+      !payload?.meetingId ||
+      typeof payload.meetingId !== 'string' ||
+      !payload?.targetSocketId ||
+      typeof payload.targetSocketId !== 'string'
+    ) {
+      socket.emit('error', { code: 400, message: 'meetingId and targetSocketId are required' });
+      return;
+    }
+
+    const { meetingId, targetSocketId } = payload;
+
+    if (!this.rooms.get(meetingId)?.has(socket.id)) {
+      socket.emit('error', { code: 403, message: 'You are not in this room' });
+      return;
+    }
+
+    if (!this.rooms.get(meetingId)?.has(targetSocketId)) {
+      socket.emit('error', { code: 404, message: 'Target socket is not in this room' });
+      return;
+    }
+
+    this.logger.log(
+      `WebRTC relay: event=${event} meetingId=${meetingId} from=${socket.id} to=${targetSocketId}`,
+    );
+
+    this.server
+      .to(targetSocketId)
+      .emit(event, { fromSocketId: socket.id, payload: payload.payload });
   }
 
   private addToRoom(


### PR DESCRIPTION
## References
- #14

## Description
- Add webrtc-offer, webrtc-answer, and webrtc-ice-candidate handlers to SignalingGateway
- Implement shared handleWebRtcRelay helper with validation: 401, 400, 403, 404
- Forward events to target via server.to(targetSocketId).emit(); SDP never logged
- Extend ClientToServerEvents and ServerToClientEvents with relay events
- Add WebRtcRelayPayload and WebRtcRelayServerPayload interfaces
- Add 8 unit tests covering relay success and all error codes
- Update docs/signaling-events.md with relay event tables and examples

## Test plan
- [x] Two sockets join same room; one emits webrtc-offer; other receives it with fromSocketId and payload
- [x] Socket not in room emits webrtc-offer; receives error code 403
- [x] webrtc-offer to missing targetSocketId returns error code 404
- [x] pnpm test passes with all 25 tests green
