### PR TITLE
feat(signaling): add lobby watcher architecture and rename WebRTC events

### DIFF
--- a/docs/signaling-events.md
+++ b/docs/signaling-events.md
@@ -71,12 +71,12 @@ Authenticated clients can join meeting rooms, receive presence updates, and requ
 
 ### Server → Client Events
 
-| Event                | Payload                                                  | Description                                             |
-| -------------------- | -------------------------------------------------------- | ------------------------------------------------------- |
-| `participant-joined` | `{ meetingId: string, participant: ParticipantInfo }`    | Broadcast to room members when a new participant joins. |
-| `participant-left`   | `{ meetingId: string, participant: ParticipantInfo }`    | Broadcast to room members when a participant leaves.    |
-| `participants-list`  | `{ meetingId: string, participants: ParticipantInfo[] }` | Response to `get-participants`.                         |
-| `error`              | `{ code: number, message: string }`                      | Error response (e.g., 403, 404).                        |
+| Event                | Payload                                                  | Description                                                                                        |
+| -------------------- | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `participant-joined` | `{ meetingId: string, participant: ParticipantInfo }`    | Broadcast to all other room members when a new participant joins.                                  |
+| `participant-left`   | `{ meetingId: string, participant: ParticipantInfo }`    | Broadcast to all remaining room members when a participant leaves or disconnects.                  |
+| `participants-list`  | `{ meetingId: string, participants: ParticipantInfo[] }` | Sent to the joining socket automatically after `join-room`, and in response to `get-participants`. |
+| `error`              | `{ code: number, message: string }`                      | Error response (e.g., 401, 403, 404).                                                              |
 
 ### `ParticipantInfo`
 
@@ -103,6 +103,12 @@ interface ParticipantInfo {
 // After connecting with a valid JWT...
 socket.emit('join-room', { meetingId: 'meeting-uuid' });
 
+// The server automatically sends the current participant list to the joining socket.
+// No need to emit get-participants manually after join-room.
+socket.on('participants-list', ({ meetingId, participants }) => {
+  console.log(`Current participants in ${meetingId}:`, participants);
+});
+
 // Listen for other participants joining
 socket.on('participant-joined', ({ meetingId, participant }) => {
   console.log(`${participant.name} joined meeting ${meetingId}`);
@@ -113,14 +119,17 @@ socket.on('participant-left', ({ meetingId, participant }) => {
   console.log(`${participant.name} left meeting ${meetingId}`);
 });
 
-// Request the current participant list
-socket.emit('get-participants', { meetingId: 'meeting-uuid' });
-socket.on('participants-list', ({ meetingId, participants }) => {
-  console.log(`Participants in ${meetingId}:`, participants);
-});
-
-// Leave a room
+// Leave a room explicitly
 socket.emit('leave-room', { meetingId: 'meeting-uuid' });
+```
+
+### `get-participants` — On-demand participant list
+
+The client can still request the participant list at any time after joining:
+
+```js
+socket.emit('get-participants', { meetingId: 'meeting-uuid' });
+// server responds with participants-list
 ```
 
 ### Presence State

--- a/docs/socket-signaling.md
+++ b/docs/socket-signaling.md
@@ -1,0 +1,381 @@
+# Socket.IO Signaling Architecture
+
+Documentation for the real-time signaling layer used by the WeMeet video meeting platform.
+
+---
+
+## Architecture Overview
+
+The signaling server uses Socket.IO and separates two distinct roles:
+
+| Role            | Description                                         |
+| --------------- | --------------------------------------------------- |
+| **Watcher**     | User watching the lobby — receives presence updates |
+| **Participant** | User inside the active video call                   |
+
+> **Key rule:** A socket connection alone does **not** make a user a participant. A user becomes a participant only by emitting `join-room`.
+
+---
+
+## Socket.IO Rooms
+
+Two room namespaces are used per meeting:
+
+| Room name           | Purpose                               |
+| ------------------- | ------------------------------------- |
+| `watch:{meetingId}` | Lobby — receives presence events only |
+| `{meetingId}`       | Video call — participants + signaling |
+
+Participants also receive lobby events because `participant-joined` and `participant-left` are broadcast to **both** rooms simultaneously.
+
+---
+
+## Authentication
+
+All sockets must authenticate at connection time. Pass a valid JWT access token in **one** of the following ways:
+
+### Option A — Recommended: `auth` option
+
+```js
+import { io } from 'socket.io-client';
+
+const socket = io('http://localhost:3000', {
+  auth: { token: '<access_token>' },
+});
+```
+
+### Option B — Fallback: `Authorization` header
+
+```js
+const socket = io('http://localhost:3000', {
+  extraHeaders: {
+    Authorization: 'Bearer <access_token>',
+  },
+});
+```
+
+Unauthenticated connections receive an `error` event (`code: 401`) and are immediately disconnected.
+
+---
+
+## Server-side State
+
+Only **one** in-memory structure is maintained — the active participant map:
+
+```typescript
+rooms: Map<meetingId, Map<socketId, ParticipantInfo>>;
+```
+
+Lobby watchers are **not** stored in memory. Watcher subscriptions are managed purely via Socket.IO rooms (`watch:{meetingId}`).
+
+---
+
+## Data Types
+
+### `ParticipantInfo`
+
+```typescript
+interface ParticipantInfo {
+  socketId: string;
+  userId: string;
+  name: string;
+  joinedAt: number; // Unix timestamp (Date.now())
+}
+```
+
+---
+
+## Client → Server Events
+
+### `watch-meeting`
+
+Subscribe a socket to lobby presence updates without joining the video call.
+
+**Payload:**
+
+```json
+{ "meetingId": "abc123" }
+```
+
+**Server behavior:**
+
+1. Validates the meeting exists.
+2. Joins the socket to the `watch:{meetingId}` room.
+3. Emits `participants-list` to the watcher with the current video-call participants.
+
+---
+
+### `join-room`
+
+Join the active video call as a participant.
+
+**Payload:**
+
+```json
+{ "meetingId": "abc123" }
+```
+
+**Server behavior:**
+
+1. Validates meeting exists and the user is a database member.
+2. Adds the participant to the in-memory rooms map.
+3. Joins the socket to the `{meetingId}` room.
+4. Emits `participant-joined` to both `{meetingId}` and `watch:{meetingId}` rooms (excluding the joining socket).
+5. Emits `participants-list` to the joining socket.
+
+---
+
+### `leave-room`
+
+Leave the video call explicitly.
+
+**Payload:**
+
+```json
+{ "meetingId": "abc123" }
+```
+
+**Server behavior:**
+
+1. Removes the participant from the in-memory map.
+2. Leaves the `{meetingId}` Socket.IO room.
+3. Emits `participant-left` to both `{meetingId}` and `watch:{meetingId}` rooms.
+
+---
+
+### `offer`
+
+Relay a WebRTC offer to a specific peer.
+
+**Payload:**
+
+```json
+{
+  "meetingId": "abc123",
+  "targetSocketId": "target-socket-id",
+  "payload": { "type": "offer", "sdp": "<sdp-string>" }
+}
+```
+
+**Server behavior:** Forwards payload to `targetSocketId` only. Sender must be in the `{meetingId}` video-call room.
+
+---
+
+### `answer`
+
+Relay a WebRTC answer to a specific peer.
+
+**Payload:**
+
+```json
+{
+  "meetingId": "abc123",
+  "targetSocketId": "target-socket-id",
+  "payload": { "type": "answer", "sdp": "<sdp-string>" }
+}
+```
+
+---
+
+### `ice-candidate`
+
+Relay an ICE candidate to a specific peer.
+
+**Payload:**
+
+```json
+{
+  "meetingId": "abc123",
+  "targetSocketId": "target-socket-id",
+  "payload": { "candidate": "<ice-candidate-string>" }
+}
+```
+
+---
+
+## Server → Client Events
+
+### `participants-list`
+
+Sent to the socket that emitted `watch-meeting` or `join-room`.
+
+**Payload:**
+
+```json
+{
+  "meetingId": "abc123",
+  "participants": [
+    {
+      "socketId": "socket-abc",
+      "userId": "user-uuid-1",
+      "name": "Alice",
+      "joinedAt": 1741651200000
+    },
+    {
+      "socketId": "socket-def",
+      "userId": "user-uuid-2",
+      "name": "Bob",
+      "joinedAt": 1741651205000
+    }
+  ]
+}
+```
+
+---
+
+### `participant-joined`
+
+Broadcast to all sockets in `{meetingId}` **and** `watch:{meetingId}` when a new participant joins the video call.
+
+**Payload:**
+
+```json
+{
+  "meetingId": "abc123",
+  "participant": {
+    "socketId": "socket-abc",
+    "userId": "user-uuid-1",
+    "name": "Alice",
+    "joinedAt": 1741651200000
+  }
+}
+```
+
+---
+
+### `participant-left`
+
+Broadcast to all sockets in `{meetingId}` **and** `watch:{meetingId}` when a participant leaves the video call (via `leave-room` or disconnect).
+
+**Payload:**
+
+```json
+{
+  "meetingId": "abc123",
+  "participant": {
+    "socketId": "socket-abc",
+    "userId": "user-uuid-1",
+    "name": "Alice",
+    "joinedAt": 1741651200000
+  }
+}
+```
+
+---
+
+### `offer` / `answer` / `ice-candidate`
+
+Forwarded to the `targetSocketId` specified by the sender. The server never broadcasts these events.
+
+**Payload (received by target):**
+
+```json
+{
+  "fromSocketId": "sender-socket-id",
+  "payload": "<original-payload>"
+}
+```
+
+---
+
+### `error`
+
+Emitted to the socket that caused the error.
+
+**Payload:**
+
+```json
+{ "code": 401, "message": "Not authenticated" }
+```
+
+| Code  | Meaning                                       |
+| ----- | --------------------------------------------- |
+| `400` | Missing or invalid field in payload           |
+| `401` | Not authenticated                             |
+| `403` | Not a member of the meeting / not in the room |
+| `404` | Meeting or target socket not found            |
+
+---
+
+## Event Flow Examples
+
+### Lobby user
+
+```js
+// 1. Connect with JWT
+const socket = io('http://localhost:3000', { auth: { token } });
+
+// 2. Subscribe to lobby updates
+socket.emit('watch-meeting', { meetingId: 'abc123' });
+
+// 3. Receive current participants immediately
+socket.on('participants-list', ({ meetingId, participants }) => {
+  console.log('Currently in call:', participants);
+});
+
+// 4. Stay updated as users join / leave
+socket.on('participant-joined', ({ participant }) => {
+  console.log(participant.name, 'joined the call');
+});
+
+socket.on('participant-left', ({ participant }) => {
+  console.log(participant.name, 'left the call');
+});
+```
+
+### User joins the video call
+
+```js
+// Join from lobby (still watching) or fresh connection
+socket.emit('join-room', { meetingId: 'abc123' });
+
+// Receive the current list including yourself
+socket.on('participants-list', ({ participants }) => {
+  initVideoGrid(participants);
+});
+
+// Others are notified via participant-joined
+```
+
+### WebRTC peer negotiation
+
+```js
+// After both peers are in the same room...
+socket.emit('offer', {
+  meetingId: 'abc123',
+  targetSocketId: 'target-socket-id',
+  payload: { type: 'offer', sdp: localSdp },
+});
+
+// Target receives:
+socket.on('offer', ({ fromSocketId, payload }) => {
+  // createAnswer() and reply via 'answer'
+});
+```
+
+### User leaves the call
+
+```js
+socket.emit('leave-room', { meetingId: 'abc123' });
+// All sockets in {meetingId} and watch:{meetingId} receive participant-left
+```
+
+---
+
+## Disconnect Cleanup
+
+When a socket disconnects for any reason (network drop, browser close, etc.):
+
+1. The server checks `socketRooms` for every meeting the socket was participating in.
+2. For each meeting, it removes the socket from the in-memory `rooms` map.
+3. It emits `participant-left` to both `{meetingId}` and `watch:{meetingId}`.
+4. **Database membership is never modified on disconnect.** Presence is in-memory only.
+
+---
+
+## Constraints & Notes
+
+- Presence is tracked **in-memory per process**. It is not shared across multiple server instances (no Redis adapter).
+- Watchers are managed via Socket.IO rooms only — never stored in the `rooms` map.
+- Empty rooms are cleaned up from the presence map automatically.
+- WebRTC signaling events (`offer`, `answer`, `ice-candidate`) are unicast — they are **never** broadcast.

--- a/src/signaling/signaling.gateway.ts
+++ b/src/signaling/signaling.gateway.ts
@@ -16,10 +16,14 @@ import { MeetingsRepository } from '../meetings/meetings.repository';
 import { JwtPayload } from '../auth/interfaces/jwt-payload.interface';
 
 export interface ParticipantInfo {
+  socketId: string;
   userId: string;
   name: string;
-  socketId: string;
-  joinedAt: Date;
+  joinedAt: number;
+}
+
+interface WatchMeetingPayload {
+  meetingId: string;
 }
 
 interface JoinRoomPayload {
@@ -30,17 +34,13 @@ interface LeaveRoomPayload {
   meetingId: string;
 }
 
-interface GetParticipantsPayload {
-  meetingId: string;
-}
-
-interface WebRtcRelayPayload {
+interface SignalingRelayPayload {
   meetingId: string;
   targetSocketId: string;
   payload: unknown;
 }
 
-interface WebRtcRelayServerPayload {
+interface SignalingRelayServerPayload {
   fromSocketId: string;
   payload: unknown;
 }
@@ -50,18 +50,18 @@ interface ServerToClientEvents {
   'participant-joined': (data: { meetingId: string; participant: ParticipantInfo }) => void;
   'participant-left': (data: { meetingId: string; participant: ParticipantInfo }) => void;
   'participants-list': (data: { meetingId: string; participants: ParticipantInfo[] }) => void;
-  'webrtc-offer': (data: WebRtcRelayServerPayload) => void;
-  'webrtc-answer': (data: WebRtcRelayServerPayload) => void;
-  'webrtc-ice-candidate': (data: WebRtcRelayServerPayload) => void;
+  offer: (data: SignalingRelayServerPayload) => void;
+  answer: (data: SignalingRelayServerPayload) => void;
+  'ice-candidate': (data: SignalingRelayServerPayload) => void;
 }
 
 interface ClientToServerEvents {
+  'watch-meeting': (payload: WatchMeetingPayload) => void;
   'join-room': (payload: JoinRoomPayload) => void;
   'leave-room': (payload: LeaveRoomPayload) => void;
-  'get-participants': (payload: GetParticipantsPayload) => void;
-  'webrtc-offer': (payload: WebRtcRelayPayload) => void;
-  'webrtc-answer': (payload: WebRtcRelayPayload) => void;
-  'webrtc-ice-candidate': (payload: WebRtcRelayPayload) => void;
+  offer: (payload: SignalingRelayPayload) => void;
+  answer: (payload: SignalingRelayPayload) => void;
+  'ice-candidate': (payload: SignalingRelayPayload) => void;
 }
 
 interface SocketData {
@@ -135,6 +135,41 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
     this.cleanupSocket(socket);
   }
 
+  @SubscribeMessage('watch-meeting')
+  async handleWatchMeeting(
+    @MessageBody() payload: WatchMeetingPayload,
+    @ConnectedSocket() socket: AuthenticatedSocket,
+  ): Promise<void> {
+    if (!socket.data.user) {
+      socket.emit('error', { code: 401, message: 'Not authenticated' });
+      return;
+    }
+
+    if (!payload?.meetingId || typeof payload.meetingId !== 'string') {
+      socket.emit('error', { code: 400, message: 'meetingId is required' });
+      return;
+    }
+
+    const { meetingId } = payload;
+
+    // Validate meeting exists
+    const meeting = await this.meetingsRepository.findById(meetingId);
+    if (!meeting) {
+      socket.emit('error', { code: 404, message: `Meeting ${meetingId} not found` });
+      return;
+    }
+
+    const watchRoom = `watch:${meetingId}`;
+    await socket.join(watchRoom);
+    this.logger.log(`Watcher joined lobby: meetingId=${meetingId} socketId=${socket.id}`);
+
+    // Send the current participant list to the watcher
+    socket.emit('participants-list', {
+      meetingId,
+      participants: this.getParticipants(meetingId),
+    });
+  }
+
   @SubscribeMessage('join-room')
   async handleJoinRoom(
     @MessageBody() payload: JoinRoomPayload,
@@ -160,7 +195,7 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
       return;
     }
 
-    // Validate user is a member of the meeting
+    // Validate user is a DB member of the meeting
     const membership = await this.meetingsRepository.findMemberByMeetingAndUser(meetingId, user.id);
     if (!membership) {
       socket.emit('error', { code: 403, message: 'Not a member of this meeting' });
@@ -170,7 +205,7 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
     // No-op if already present in the room (prevents duplicate participant-joined events)
     if (this.rooms.get(meetingId)?.has(socket.id)) return;
 
-    // Join Socket.IO room and record presence
+    // Join the video-call Socket.IO room and record presence
     await socket.join(meetingId);
     const participant = this.addToRoom(meetingId, socket.id, user);
 
@@ -178,8 +213,18 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
       `User joined room: meetingId=${meetingId} socketId=${socket.id} userId=${user.id}`,
     );
 
-    // Broadcast to other room members
-    socket.to(meetingId).emit('participant-joined', { meetingId, participant });
+    // Broadcast participant-joined to video-call participants and lobby watchers
+    // socket.to() excludes the sender; emit to the union of both rooms
+    socket.to(meetingId).to(`watch:${meetingId}`).emit('participant-joined', {
+      meetingId,
+      participant,
+    });
+
+    // Send the current participant list to the joining socket
+    socket.emit('participants-list', {
+      meetingId,
+      participants: this.getParticipants(meetingId),
+    });
   }
 
   @SubscribeMessage('leave-room')
@@ -202,62 +247,33 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
     this.removeFromRoomAndBroadcast(meetingId, socket);
   }
 
-  @SubscribeMessage('get-participants')
-  async handleGetParticipants(
-    @MessageBody() payload: GetParticipantsPayload,
-    @ConnectedSocket() socket: AuthenticatedSocket,
-  ): Promise<void> {
-    const user = socket.data.user;
-    if (!user) {
-      socket.emit('error', { code: 401, message: 'Not authenticated' });
-      return;
-    }
-
-    if (!payload?.meetingId || typeof payload.meetingId !== 'string') {
-      socket.emit('error', { code: 400, message: 'meetingId is required' });
-      return;
-    }
-
-    const { meetingId } = payload;
-
-    // Validate user is a member of the meeting
-    const membership = await this.meetingsRepository.findMemberByMeetingAndUser(meetingId, user.id);
-    if (!membership) {
-      socket.emit('error', { code: 403, message: 'Not a member of this meeting' });
-      return;
-    }
-
-    const participants = this.getParticipants(meetingId);
-    socket.emit('participants-list', { meetingId, participants });
-  }
-
-  @SubscribeMessage('webrtc-offer')
-  handleWebRtcOffer(
-    @MessageBody() payload: WebRtcRelayPayload,
+  @SubscribeMessage('offer')
+  handleOffer(
+    @MessageBody() payload: SignalingRelayPayload,
     @ConnectedSocket() socket: AuthenticatedSocket,
   ): void {
-    this.handleWebRtcRelay('webrtc-offer', payload, socket);
+    this.handleSignalingRelay('offer', payload, socket);
   }
 
-  @SubscribeMessage('webrtc-answer')
-  handleWebRtcAnswer(
-    @MessageBody() payload: WebRtcRelayPayload,
+  @SubscribeMessage('answer')
+  handleAnswer(
+    @MessageBody() payload: SignalingRelayPayload,
     @ConnectedSocket() socket: AuthenticatedSocket,
   ): void {
-    this.handleWebRtcRelay('webrtc-answer', payload, socket);
+    this.handleSignalingRelay('answer', payload, socket);
   }
 
-  @SubscribeMessage('webrtc-ice-candidate')
-  handleWebRtcIceCandidate(
-    @MessageBody() payload: WebRtcRelayPayload,
+  @SubscribeMessage('ice-candidate')
+  handleIceCandidate(
+    @MessageBody() payload: SignalingRelayPayload,
     @ConnectedSocket() socket: AuthenticatedSocket,
   ): void {
-    this.handleWebRtcRelay('webrtc-ice-candidate', payload, socket);
+    this.handleSignalingRelay('ice-candidate', payload, socket);
   }
 
-  private handleWebRtcRelay(
-    event: 'webrtc-offer' | 'webrtc-answer' | 'webrtc-ice-candidate',
-    payload: WebRtcRelayPayload,
+  private handleSignalingRelay(
+    event: 'offer' | 'answer' | 'ice-candidate',
+    payload: SignalingRelayPayload,
     socket: AuthenticatedSocket,
   ): void {
     if (!socket.data.user) {
@@ -306,10 +322,10 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
     }
 
     const participant: ParticipantInfo = {
+      socketId,
       userId: user.id,
       name: user.name ?? 'Anonymous',
-      socketId,
-      joinedAt: new Date(),
+      joinedAt: Date.now(),
     };
 
     this.rooms.get(meetingId)!.set(socketId, participant);
@@ -373,7 +389,11 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
       `User left room: meetingId=${meetingId} socketId=${socket.id} userId=${participant.userId}`,
     );
 
-    this.server.to(meetingId).emit('participant-left', { meetingId, participant });
+    // Notify video-call participants and lobby watchers
+    this.server
+      .to(meetingId)
+      .to(`watch:${meetingId}`)
+      .emit('participant-left', { meetingId, participant });
   }
 
   private extractToken(socket: AuthenticatedSocket): string | undefined {


### PR DESCRIPTION
## Description
- Introduce a lobby/watcher pattern using a dedicated `watch:{meetingId}` Socket.IO room alongside the existing video-call room
- Add `watch-meeting` event handler: socket joins the lobby room and immediately receives the current `participants-list`
- Update `join-room` to broadcast `participant-joined` to both the video-call room and the lobby room simultaneously
- Update disconnect/leave cleanup to emit `participant-left` to both rooms
- Rename WebRTC relay events from `webrtc-offer/answer/ice-candidate` to `offer/answer/ice-candidate`
- Remove the `get-participants` event; the participant list is now pushed automatically on join and on `watch-meeting`
- Add `docs/socket-signaling.md` as the canonical reference for the new architecture
- Update `docs/signaling-events.md` to reflect auto-emit behaviour and remove stale event references

## Test plan
- [ ] Connect a socket with a valid JWT and emit `watch-meeting`; verify `participants-list` is received immediately
- [ ] Emit `join-room` from a second socket; verify both the video-call socket and the watcher socket receive `participant-joined`
- [ ] Verify the joining socket receives `participants-list` automatically after `join-room`
- [ ] Disconnect or emit `leave-room` from a participant; verify both rooms receive `participant-left`
- [ ] Verify `offer`, `answer`, and `ice-candidate` relay events work correctly between two joined participants
- [ ] Verify that a socket not in the room cannot relay WebRTC signals (expects a 403 error event)