### PR TITLE
feat(signaling): extract session service, add DTO validation and rate limiting

### DIFF
--- a/.github/plans/WM-5.md
+++ b/.github/plans/WM-5.md
@@ -1,0 +1,169 @@
+# WM-5: Production-grade signaling & meeting lifecycle management
+
+---
+
+## 1. Feature Summary
+
+This feature hardens the SignalingGateway for production by extracting in-memory session state into an injectable SignalingSessionService, adding class-validator-based DTO validation for all signaling relay payloads, introducing per-socket sliding-window rate limiting for offer/answer/ice-candidate events, and improving structured logging across every lifecycle event. The design ensures the session service can later be swapped for a Redis-backed adapter without changing any gateway handler code.
+
+---
+
+## 2. Problem Statement
+
+The current gateway inlines all state management (the rooms and socketRooms Maps and their mutation methods) directly in SignalingGateway. This means:
+
+- The state is tightly coupled to a single process instance — adding a second server node would cause split-brain participant lists.
+- Payload validation for relay events is done with ad-hoc typeof checks that miss nested payload structure, allowing malformed SDP or ICE objects to be blindly forwarded.
+- There is no protection against a misbehaving or compromised client flooding the relay path with thousands of events per second.
+- Log output is inconsistent — some paths omit meetingId or userId — making WebRTC debugging from logs alone unreliable.
+- Business logic and state management mixed inside the gateway make unit testing hard.
+
+---
+
+## 3. Technical Design
+
+### Affected modules
+
+| Path                                            | Change                                                                                     |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| src/signaling/signaling.module.ts               | Register SignalingSessionService as a provider                                             |
+| src/signaling/signaling.gateway.ts              | Inject SignalingSessionService; remove inline state; add rate-limit guard; improve logging |
+| src/signaling/signaling-session.service.ts      | **New** — owns all session state and exposes the ISignalingSessionService interface        |
+| src/signaling/signaling-session.interface.ts    | **New** — defines ISignalingSessionService abstract contract                               |
+| src/signaling/dto/relay.dto.ts                  | **New** — OfferDto, AnswerDto, IceCandidateDto validated with class-validator              |
+| src/signaling/dto/watch-meeting.dto.ts          | **New** — WatchMeetingDto                                                                  |
+| src/signaling/dto/join-room.dto.ts              | **New** — JoinRoomDto                                                                      |
+| src/signaling/dto/leave-room.dto.ts             | **New** — LeaveRoomDto                                                                     |
+| src/signaling/signaling.gateway.spec.ts         | Update existing spec                                                                       |
+| src/signaling/signaling-session.service.spec.ts | **New** — unit tests for session service                                                   |
+
+### Services to modify or create
+
+#### ISignalingSessionService (interface)
+
+Defines the contract the gateway depends on:
+
+- addParticipant(meetingId, socketId, user): ParticipantInfo
+- removeParticipant(meetingId, socketId): ParticipantInfo | undefined
+- getParticipants(meetingId): ParticipantInfo[]
+- getSocketRooms(socketId): Set<string>
+- isParticipant(meetingId, socketId): boolean
+
+Keeping the interface separate allows a future RedisSignalingSessionService to be swapped in via NestJS DI token.
+
+#### SignalingSessionService (@Injectable())
+
+- Contains rooms: Map<string, Map<string, ParticipantInfo>> and socketRooms: Map<string, Set<string>>.
+- Implements ISignalingSessionService.
+- removeParticipant deletes the room entry from rooms when the last participant leaves (last-one-out lifecycle rule).
+- Provided as { provide: SIGNALING_SESSION_SERVICE, useClass: SignalingSessionService } using an injection token so the gateway depends on the interface, not the concrete class.
+
+#### SignalingGateway (modify)
+
+- Inject ISignalingSessionService via @Inject(SIGNALING_SESSION_SERVICE).
+- Remove the inline rooms, socketRooms, addToRoom, removeFromRoom, getParticipants, cleanupSocket members.
+- Add a rateLimiter: Map<socketId, { count: number; windowStart: number }> within the gateway (not the session service) — rate limiting is an I/O concern, not a state concern.
+- Validate all payloads using plainToInstance + validateSync from class-validator/class-transformer (same pattern as REST layer uses ValidationPipe).
+- Emit structured log context on every event using the fields: event, meetingId, socketId, userId, timestamp.
+
+### Database changes
+
+None — no Prisma schema changes required. The session is entirely in-memory.
+
+### API endpoints
+
+No new REST endpoints. All changes are Socket.IO events. Existing event signatures are preserved; only validation and internal handling change.
+
+### Validation rules
+
+All DTOs use class-validator decorators. Validated manually inside each handler using plainToInstance + validateSync (since ValidationPipe only applies to HTTP — Socket.IO handlers need explicit validation):
+
+| DTO             | Fields         | Rules                               |
+| --------------- | -------------- | ----------------------------------- |
+| WatchMeetingDto | meetingId      | @IsString() @IsNotEmpty() @IsUUID() |
+| JoinRoomDto     | meetingId      | @IsString() @IsNotEmpty() @IsUUID() |
+| LeaveRoomDto    | meetingId      | @IsString() @IsNotEmpty() @IsUUID() |
+| RelayDto        | meetingId      | @IsString() @IsNotEmpty() @IsUUID() |
+| RelayDto        | targetSocketId | @IsString() @IsNotEmpty()           |
+| RelayDto        | payload        | @IsNotEmpty() (any object)          |
+
+Validation failures emit error { code: 400, message: <first constraint message> } and return early — no relay occurs.
+
+**Rate limiting (in SignalingGateway):**
+
+- Sliding window: 30 relay events per socket per 10-second window (configurable constants at the top of the file).
+- On each relay call: read the socket rate-limit entry, reset window if Date.now() - windowStart >= WINDOW_MS, increment count, reject with error { code: 429 } if count > LIMIT.
+- The map is cleaned up on socket disconnect.
+
+---
+
+## 4. Edge Cases
+
+| Scenario                                                   | Handling                                                                                                                                     |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Socket disconnects while handleJoinRoom is awaiting the DB | The disconnect handler fires; since the socket was not yet added to rooms, getSocketRooms returns empty — no-op cleanup, no double broadcast |
+| leave-room called when socket is not in the room           | removeParticipant returns undefined; removeFromRoomAndBroadcast no-ops silently                                                              |
+| Same socket emits join-room twice for the same meeting     | Guard isParticipant(meetingId, socket.id) returns true — early return, no duplicate participant-joined                                       |
+| targetSocketId is the sender own socket.id                 | Relay is allowed (edge case for self-loopback tests); no special restriction needed                                                          |
+| payload field on RelayDto is null                          | @IsNotEmpty() catches this and returns 400                                                                                                   |
+| Rate limiter Map grows indefinitely                        | Cleared in handleDisconnect for the disconnecting socket entry                                                                               |
+| Last participant leaves via disconnect (not leave-room)    | cleanupSocket triggers removeFromRoomAndBroadcast which calls removeParticipant and clears the room Map entry                                |
+| Two sockets race to be the last participant                | JavaScript is single-threaded in Node.js; Map mutations are synchronous — no actual race condition                                           |
+
+---
+
+## 5. Implementation Plan
+
+1. **Define the session service interface** — Create src/signaling/signaling-session.interface.ts with ISignalingSessionService, the SIGNALING_SESSION_SERVICE injection token, and re-export ParticipantInfo.
+
+2. **Implement SignalingSessionService** — Move rooms, socketRooms, addToRoom, removeFromRoom, getParticipants, cleanupSocket logic from the gateway into the new service. Implement last-participant room deletion in removeParticipant. Decorate with @Injectable(). Keep the service free of any Server reference — broadcasting stays in the gateway.
+
+3. **Create Socket.IO DTOs** — Add src/signaling/dto/ with WatchMeetingDto, JoinRoomDto, LeaveRoomDto, and RelayDto using class-validator decorators. RelayDto is shared by offer/answer/ice-candidate handlers.
+
+4. **Add a reusable validateSocketPayload helper** — A private gateway method that calls plainToInstance + validateSync and emits a 400 error on the socket if validation fails, returning a typed instance or null.
+
+5. **Add the in-gateway rate limiter** — Add RATE_LIMIT and RATE_WINDOW_MS constants and the rateLimits Map field. Implement checkRateLimit(socket): boolean used by the three relay handlers. Clean up the map entry in handleDisconnect.
+
+6. **Refactor SignalingGateway** — Inject the session service via the DI token. Replace all direct Map access with session service calls. Replace ad-hoc type checks with validateSocketPayload. Add rate-limit calls in the relay handlers. Improve all log calls to include event, meetingId, socketId, userId, and ISO timestamp.
+
+7. **Update SignalingModule** — Register the DI token provider and SignalingSessionService.
+
+8. **Write unit tests for SignalingSessionService** — Test addParticipant, removeParticipant (verifies room deletion on last leave), getParticipants (empty and non-empty), and isParticipant.
+
+---
+
+## 6. Implementation Order
+
+1. Create src/signaling/signaling-session.interface.ts (interface + injection token)
+2. Create src/signaling/signaling-session.service.ts (concrete implementation)
+3. Create src/signaling/dto/watch-meeting.dto.ts
+4. Create src/signaling/dto/join-room.dto.ts
+5. Create src/signaling/dto/leave-room.dto.ts
+6. Create src/signaling/dto/relay.dto.ts
+7. Refactor src/signaling/signaling.gateway.ts (inject service, DTOs, rate limiter, logging)
+8. Update src/signaling/signaling.module.ts (register new provider)
+9. Write src/signaling/signaling-session.service.spec.ts
+10. Verify pnpm build and pnpm test pass with no errors
+
+---
+
+## 7. Task Breakdown
+
+- [ ] Create src/signaling/signaling-session.interface.ts defining ISignalingSessionService and SIGNALING_SESSION_SERVICE token
+- [ ] Create src/signaling/signaling-session.service.ts implementing the interface with addParticipant, removeParticipant (with last-participant cleanup), getParticipants, getSocketRooms, isParticipant
+- [ ] Create src/signaling/dto/watch-meeting.dto.ts with @IsString() @IsNotEmpty() @IsUUID() meetingId
+- [ ] Create src/signaling/dto/join-room.dto.ts with same meetingId validation
+- [ ] Create src/signaling/dto/leave-room.dto.ts with same meetingId validation
+- [ ] Create src/signaling/dto/relay.dto.ts with meetingId (UUID), targetSocketId (string non-empty), payload (non-empty)
+- [ ] Add validateSocketPayload<T>(socket, cls, data): T | null private method to gateway using plainToInstance + validateSync
+- [ ] Replace all ad-hoc typeof payload checks in gateway handlers with validateSocketPayload
+- [ ] Add RATE_LIMIT = 30 and RATE_WINDOW_MS = 10000 constants and rateLimits Map to gateway
+- [ ] Implement checkRateLimit(socketId): boolean in gateway; call it in handleOffer, handleAnswer, handleIceCandidate
+- [ ] Clear rateLimits entry for socket in handleDisconnect
+- [ ] Inject ISignalingSessionService via @Inject(SIGNALING_SESSION_SERVICE) in gateway constructor
+- [ ] Remove rooms, socketRooms, addToRoom, removeFromRoom, getParticipants, cleanupSocket from gateway; replace with session service calls
+- [ ] Update all this.logger calls to include event, meetingId, socketId, userId, and ISO timestamp fields
+- [ ] Register { provide: SIGNALING_SESSION_SERVICE, useClass: SignalingSessionService } in SignalingModule.providers
+- [ ] Write unit tests in signaling-session.service.spec.ts: addParticipant stores entry, removeParticipant returns undefined for unknown, last-participant clears Map, getParticipants returns correct array
+- [ ] Run pnpm build — zero TypeScript errors
+- [ ] Run pnpm test — all tests pass

--- a/docs/signaling-events.md
+++ b/docs/signaling-events.md
@@ -44,10 +44,10 @@ const socket = io('http://localhost:3000', {
 
 ### Server-side Lifecycle
 
-| Hook               | Behaviour                                                                                                          |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------ |
-| `handleConnection` | Validates JWT, loads user from DB, sets `socket.data.user`. Disconnects on failure.                                |
-| `handleDisconnect` | Logs disconnect with `socketId` and `userId`. Removes the socket from all rooms and broadcasts `participant-left`. |
+| Hook               | Behaviour                                                                                                                      |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| `handleConnection` | Validates JWT, loads user from DB, sets `socket.data.user`. Disconnects on failure.                                            |
+| `handleDisconnect` | Removes the socket from all rooms, broadcasts `participant-left` to the call room and lobby, and clears the rate-limit bucket. |
 
 ---
 
@@ -59,24 +59,24 @@ After a successful handshake, `socket.data.user` is populated with the Prisma `U
 
 ## Room Presence
 
-Authenticated clients can join meeting rooms, receive presence updates, and request participant lists.
+Authenticated clients can join meeting rooms, watch the lobby, and receive presence updates.
 
 ### Client → Server Events
 
-| Event              | Payload                 | Description                                                               |
-| ------------------ | ----------------------- | ------------------------------------------------------------------------- |
-| `join-room`        | `{ meetingId: string }` | Join a meeting room. Server validates meeting existence and membership.   |
-| `leave-room`       | `{ meetingId: string }` | Leave a meeting room. Server removes the socket and broadcasts departure. |
-| `get-participants` | `{ meetingId: string }` | Request the current participant list for a room.                          |
+| Event           | Payload                 | Description                                                                                       |
+| --------------- | ----------------------- | ------------------------------------------------------------------------------------------------- |
+| `join-room`     | `{ meetingId: string }` | Join a meeting room. Server validates meeting existence and membership.                           |
+| `leave-room`    | `{ meetingId: string }` | Leave a meeting room. Server removes the socket and broadcasts departure.                         |
+| `watch-meeting` | `{ meetingId: string }` | Join the lobby watcher room (`watch:{meetingId}`). Receives current participant list immediately. |
 
 ### Server → Client Events
 
-| Event                | Payload                                                  | Description                                                                                        |
-| -------------------- | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `participant-joined` | `{ meetingId: string, participant: ParticipantInfo }`    | Broadcast to all other room members when a new participant joins.                                  |
-| `participant-left`   | `{ meetingId: string, participant: ParticipantInfo }`    | Broadcast to all remaining room members when a participant leaves or disconnects.                  |
-| `participants-list`  | `{ meetingId: string, participants: ParticipantInfo[] }` | Sent to the joining socket automatically after `join-room`, and in response to `get-participants`. |
-| `error`              | `{ code: number, message: string }`                      | Error response (e.g., 401, 403, 404).                                                              |
+| Event                | Payload                                                  | Description                                                                                                              |
+| -------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `participant-joined` | `{ meetingId: string, participant: ParticipantInfo }`    | Broadcast to all members of the call room and the `watch:{meetingId}` lobby when a new participant joins.                |
+| `participant-left`   | `{ meetingId: string, participant: ParticipantInfo }`    | Broadcast to all members of the call room and the `watch:{meetingId}` lobby when a participant leaves or disconnects.    |
+| `participants-list`  | `{ meetingId: string, participants: ParticipantInfo[] }` | Sent automatically to the joining socket after `join-room`, and immediately to the watcher socket after `watch-meeting`. |
+| `error`              | `{ code: number, message: string }`                      | Error response (e.g., 401, 403, 404).                                                                                    |
 
 ### `ParticipantInfo`
 
@@ -93,6 +93,7 @@ interface ParticipantInfo {
 
 | Code  | Meaning                     |
 | ----- | --------------------------- |
+| `400` | Invalid or missing payload  |
 | `401` | Not authenticated           |
 | `403` | Not a member of the meeting |
 | `404` | Meeting not found           |
@@ -104,7 +105,6 @@ interface ParticipantInfo {
 socket.emit('join-room', { meetingId: 'meeting-uuid' });
 
 // The server automatically sends the current participant list to the joining socket.
-// No need to emit get-participants manually after join-room.
 socket.on('participants-list', ({ meetingId, participants }) => {
   console.log(`Current participants in ${meetingId}:`, participants);
 });
@@ -123,67 +123,94 @@ socket.on('participant-left', ({ meetingId, participant }) => {
 socket.emit('leave-room', { meetingId: 'meeting-uuid' });
 ```
 
-### `get-participants` — On-demand participant list
-
-The client can still request the participant list at any time after joining:
+### Example: Watching the Lobby
 
 ```js
-socket.emit('get-participants', { meetingId: 'meeting-uuid' });
-// server responds with participants-list
+// Watch participant list without joining the call (e.g. pre-call lobby screen)
+socket.emit('watch-meeting', { meetingId: 'meeting-uuid' });
+
+// Server immediately sends the current participant list
+socket.on('participants-list', ({ meetingId, participants }) => {
+  console.log(`Lobby sees ${participants.length} participant(s)`);
+});
+
+// Also receives join/leave updates as the call evolves
+socket.on('participant-joined', ({ participant }) => {
+  console.log(`${participant.name} entered the call`);
+});
+
+socket.on('participant-left', ({ participant }) => {
+  console.log(`${participant.name} left the call`);
+});
 ```
 
 ### Presence State
 
-- Presence is tracked in-memory per process. It is **not** shared across multiple server instances.
-- When a socket disconnects (abruptly or gracefully), the server automatically removes it from all rooms and broadcasts `participant-left`.
-- Empty rooms are cleaned up from the presence map automatically.
+- Presence is managed by `SignalingSessionService` — an injectable service with a typed interface designed to support Redis-backed adapters in a future phase.
+- When a socket disconnects (abruptly or gracefully), the server removes it from all rooms and broadcasts `participant-left` to both the call room and the `watch:{meetingId}` lobby.
+- When the last participant leaves, the meeting entry is cleared from the in-memory maps. The lobby room persists independently.
 
 ---
 
-## WebRTC Signaling Relay
+## Signaling Relay
 
-Authenticated participants who are joined to a meeting room can relay WebRTC negotiation messages to a specific peer. The server forwards the message transparently — it never parses, logs, or stores SDP or ICE candidate content.
+Authenticated participants who are joined to a meeting room can relay WebRTC negotiation messages to a specific peer. All payloads are validated before forwarding; the server never parses, logs, or stores SDP or ICE content.
+
+### Payload Validation
+
+All relay events are validated before forwarding. Missing or malformed fields result in an `error` event with `code: 400` and no relay occurs.
+
+| Field            | Rule                                   |
+| ---------------- | -------------------------------------- |
+| `meetingId`      | Required, non-empty, valid UUID v4     |
+| `targetSocketId` | Required, non-empty string             |
+| `payload`        | Required, any non-null/non-empty value |
+
+### Rate Limiting
+
+Each socket may send at most **30 relay events per 10-second sliding window** across `offer`, `answer`, and `ice-candidate` combined. Exceeding the limit emits `error { code: 429 }` and drops the event. The bucket resets automatically and is cleared on disconnect.
 
 ### Client → Server Events
 
-| Event                  | Payload                                                           | Description                                |
-| ---------------------- | ----------------------------------------------------------------- | ------------------------------------------ |
-| `webrtc-offer`         | `{ meetingId: string, targetSocketId: string, payload: unknown }` | Relay a WebRTC offer to the target peer.   |
-| `webrtc-answer`        | `{ meetingId: string, targetSocketId: string, payload: unknown }` | Relay a WebRTC answer to the target peer.  |
-| `webrtc-ice-candidate` | `{ meetingId: string, targetSocketId: string, payload: unknown }` | Relay an ICE candidate to the target peer. |
+| Event           | Payload                                                           | Description                                |
+| --------------- | ----------------------------------------------------------------- | ------------------------------------------ |
+| `offer`         | `{ meetingId: string, targetSocketId: string, payload: unknown }` | Relay a WebRTC offer to the target peer.   |
+| `answer`        | `{ meetingId: string, targetSocketId: string, payload: unknown }` | Relay a WebRTC answer to the target peer.  |
+| `ice-candidate` | `{ meetingId: string, targetSocketId: string, payload: unknown }` | Relay an ICE candidate to the target peer. |
 
 ### Server → Client Events (relayed to target)
 
-| Event                  | Payload                                      | Description                              |
-| ---------------------- | -------------------------------------------- | ---------------------------------------- |
-| `webrtc-offer`         | `{ fromSocketId: string, payload: unknown }` | Forwarded offer from a peer.             |
-| `webrtc-answer`        | `{ fromSocketId: string, payload: unknown }` | Forwarded answer from a peer.            |
-| `webrtc-ice-candidate` | `{ fromSocketId: string, payload: unknown }` | Forwarded ICE candidate from a peer.     |
-| `error`                | `{ code: number, message: string }`          | Emitted to sender on validation failure. |
+| Event           | Payload                                      | Description                              |
+| --------------- | -------------------------------------------- | ---------------------------------------- |
+| `offer`         | `{ fromSocketId: string, payload: unknown }` | Forwarded offer from a peer.             |
+| `answer`        | `{ fromSocketId: string, payload: unknown }` | Forwarded answer from a peer.            |
+| `ice-candidate` | `{ fromSocketId: string, payload: unknown }` | Forwarded ICE candidate from a peer.     |
+| `error`         | `{ code: number, message: string }`          | Emitted to sender on validation failure. |
 
 ### Error Codes
 
-| Code  | Meaning                                           |
-| ----- | ------------------------------------------------- |
-| `400` | Missing or invalid `meetingId` / `targetSocketId` |
-| `401` | Not authenticated                                 |
-| `403` | Sender is not joined to the specified room        |
-| `404` | Target socket is not in the room                  |
+| Code  | Meaning                                                        |
+| ----- | -------------------------------------------------------------- |
+| `400` | Invalid or missing `meetingId`, `targetSocketId`, or `payload` |
+| `401` | Not authenticated                                              |
+| `403` | Sender is not joined to the specified room                     |
+| `404` | Target socket is not in the room                               |
+| `429` | Rate limit exceeded (30 relay events \/ 10 s per socket)       |
 
 ### Example: Sending a WebRTC Offer
 
 ```js
 // After both peers have joined the same room...
-socket.emit('webrtc-offer', {
+socket.emit('offer', {
   meetingId: 'meeting-uuid',
   targetSocketId: 'target-socket-id',
   payload: { type: 'offer', sdp: '<sdp-string>' },
 });
 
 // The target peer receives:
-socket.on('webrtc-offer', ({ fromSocketId, payload }) => {
+socket.on('offer', ({ fromSocketId, payload }) => {
   console.log(`Offer from ${fromSocketId}`, payload);
-  // createAnswer and relay back via webrtc-answer
+  // createAnswer and relay back via answer
 });
 ```
 
@@ -191,4 +218,4 @@ socket.on('webrtc-offer', ({ fromSocketId, payload }) => {
 
 ## Out of Scope
 
-- Distributed presence (Redis adapter)
+- Distributed presence (Redis adapter) — the `ISignalingSessionService` interface is designed to support this without gateway changes.

--- a/src/signaling/dto/answer.dto.ts
+++ b/src/signaling/dto/answer.dto.ts
@@ -1,0 +1,15 @@
+import { IsDefined, IsNotEmpty, IsString, IsUUID } from 'class-validator';
+
+export class AnswerDto {
+  @IsString()
+  @IsNotEmpty()
+  @IsUUID()
+  meetingId!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  targetSocketId!: string;
+
+  @IsDefined()
+  payload!: unknown;
+}

--- a/src/signaling/dto/ice-candidate.dto.ts
+++ b/src/signaling/dto/ice-candidate.dto.ts
@@ -1,0 +1,15 @@
+import { IsDefined, IsNotEmpty, IsString, IsUUID } from 'class-validator';
+
+export class IceCandidateDto {
+  @IsString()
+  @IsNotEmpty()
+  @IsUUID()
+  meetingId!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  targetSocketId!: string;
+
+  @IsDefined()
+  payload!: unknown;
+}

--- a/src/signaling/dto/join-room.dto.ts
+++ b/src/signaling/dto/join-room.dto.ts
@@ -1,0 +1,8 @@
+import { IsNotEmpty, IsString, IsUUID } from 'class-validator';
+
+export class JoinRoomDto {
+  @IsString()
+  @IsNotEmpty()
+  @IsUUID()
+  meetingId!: string;
+}

--- a/src/signaling/dto/leave-room.dto.ts
+++ b/src/signaling/dto/leave-room.dto.ts
@@ -1,0 +1,8 @@
+import { IsNotEmpty, IsString, IsUUID } from 'class-validator';
+
+export class LeaveRoomDto {
+  @IsString()
+  @IsNotEmpty()
+  @IsUUID()
+  meetingId!: string;
+}

--- a/src/signaling/dto/offer.dto.ts
+++ b/src/signaling/dto/offer.dto.ts
@@ -1,0 +1,15 @@
+import { IsDefined, IsNotEmpty, IsString, IsUUID } from 'class-validator';
+
+export class OfferDto {
+  @IsString()
+  @IsNotEmpty()
+  @IsUUID()
+  meetingId!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  targetSocketId!: string;
+
+  @IsDefined()
+  payload!: unknown;
+}

--- a/src/signaling/dto/relay.dto.ts
+++ b/src/signaling/dto/relay.dto.ts
@@ -1,0 +1,15 @@
+import { IsDefined, IsNotEmpty, IsString, IsUUID } from 'class-validator';
+
+export class RelayDto {
+  @IsString()
+  @IsNotEmpty()
+  @IsUUID()
+  meetingId!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  targetSocketId!: string;
+
+  @IsDefined()
+  payload!: unknown;
+}

--- a/src/signaling/dto/watch-meeting.dto.ts
+++ b/src/signaling/dto/watch-meeting.dto.ts
@@ -1,0 +1,8 @@
+import { IsNotEmpty, IsString, IsUUID } from 'class-validator';
+
+export class WatchMeetingDto {
+  @IsString()
+  @IsNotEmpty()
+  @IsUUID()
+  meetingId!: string;
+}

--- a/src/signaling/signaling-rate-limiter.service.spec.ts
+++ b/src/signaling/signaling-rate-limiter.service.spec.ts
@@ -1,0 +1,127 @@
+import { SignalingRateLimiterService } from './signaling-rate-limiter.service';
+import type { SignalingEvent } from './signaling-rate-limiter.service';
+
+describe('SignalingRateLimiterService', () => {
+  let service: SignalingRateLimiterService;
+
+  beforeEach(() => {
+    service = new SignalingRateLimiterService();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // ── check ─────────────────────────────────────────────────────────────
+
+  describe('check', () => {
+    it('should allow the first event', () => {
+      expect(service.check('socket-1', 'offer')).toBe(true);
+    });
+
+    it('should allow events up to the offer limit (5)', () => {
+      for (let i = 0; i < 5; i++) {
+        expect(service.check('socket-1', 'offer')).toBe(true);
+      }
+    });
+
+    it('should block the 6th offer event within the window', () => {
+      for (let i = 0; i < 5; i++) {
+        service.check('socket-1', 'offer');
+      }
+      expect(service.check('socket-1', 'offer')).toBe(false);
+    });
+
+    it('should allow events up to the answer limit (5)', () => {
+      for (let i = 0; i < 5; i++) {
+        expect(service.check('socket-1', 'answer')).toBe(true);
+      }
+    });
+
+    it('should allow up to 50 ice-candidate events', () => {
+      for (let i = 0; i < 50; i++) {
+        expect(service.check('socket-1', 'ice-candidate')).toBe(true);
+      }
+    });
+
+    it('should block the 51st ice-candidate event within the window', () => {
+      for (let i = 0; i < 50; i++) {
+        service.check('socket-1', 'ice-candidate');
+      }
+      expect(service.check('socket-1', 'ice-candidate')).toBe(false);
+    });
+
+    it('should reset after the window expires', () => {
+      for (let i = 0; i < 5; i++) {
+        service.check('socket-1', 'offer');
+      }
+      // Advance time past the 10s window
+      jest.advanceTimersByTime(10_001);
+      expect(service.check('socket-1', 'offer')).toBe(true);
+    });
+
+    it('should track limits independently per event type', () => {
+      for (let i = 0; i < 5; i++) {
+        service.check('socket-1', 'offer');
+      }
+      // offer is exhausted but answer is not
+      expect(service.check('socket-1', 'offer')).toBe(false);
+      expect(service.check('socket-1', 'answer')).toBe(true);
+    });
+
+    it('should track limits independently per socket', () => {
+      for (let i = 0; i < 5; i++) {
+        service.check('socket-1', 'offer');
+      }
+      // socket-1 is exhausted but socket-2 is not
+      expect(service.check('socket-1', 'offer')).toBe(false);
+      expect(service.check('socket-2', 'offer')).toBe(true);
+    });
+
+    it('should return true for unknown events (passthrough)', () => {
+      expect(service.check('socket-1', 'unknown-event' as SignalingEvent)).toBe(true);
+    });
+  });
+
+  // ── clearSocket ──────────────────────────────────────────────────────
+
+  describe('clearSocket', () => {
+    it('should allow events again after clearSocket is called', () => {
+      for (let i = 0; i < 5; i++) {
+        service.check('socket-1', 'offer');
+      }
+      expect(service.check('socket-1', 'offer')).toBe(false);
+
+      service.clearSocket('socket-1');
+
+      expect(service.check('socket-1', 'offer')).toBe(true);
+    });
+
+    it('should not affect other sockets', () => {
+      for (let i = 0; i < 5; i++) {
+        service.check('socket-1', 'offer');
+        service.check('socket-2', 'offer');
+      }
+      service.clearSocket('socket-1');
+
+      expect(service.check('socket-1', 'offer')).toBe(true);
+      expect(service.check('socket-2', 'offer')).toBe(false);
+    });
+
+    it('should clear all event buckets for the socket', () => {
+      for (let i = 0; i < 5; i++) {
+        service.check('socket-1', 'offer');
+        service.check('socket-1', 'answer');
+      }
+      service.clearSocket('socket-1');
+
+      expect(service.check('socket-1', 'offer')).toBe(true);
+      expect(service.check('socket-1', 'answer')).toBe(true);
+    });
+
+    it('should not throw when clearing a socket with no buckets', () => {
+      expect(() => service.clearSocket('unknown-socket')).not.toThrow();
+    });
+  });
+});

--- a/src/signaling/signaling-rate-limiter.service.ts
+++ b/src/signaling/signaling-rate-limiter.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common';
+
+export type SignalingEvent = 'offer' | 'answer' | 'ice-candidate';
+
+interface RateLimitConfig {
+  limit: number;
+  windowMs: number;
+}
+
+interface RateBucket {
+  count: number;
+  windowStart: number;
+}
+
+const EVENT_LIMITS: Record<SignalingEvent, RateLimitConfig> = {
+  offer: { limit: 5, windowMs: 10_000 },
+  answer: { limit: 5, windowMs: 10_000 },
+  'ice-candidate': { limit: 50, windowMs: 10_000 },
+};
+
+@Injectable()
+export class SignalingRateLimiterService {
+  private readonly buckets = new Map<string, RateBucket>();
+
+  check(socketId: string, event: SignalingEvent): boolean {
+    const config = EVENT_LIMITS[event];
+    if (!config) return true;
+    const key = `${socketId}:${event}`;
+    const now = Date.now();
+    const bucket = this.buckets.get(key);
+    if (!bucket || now - bucket.windowStart >= config.windowMs) {
+      this.buckets.set(key, { count: 1, windowStart: now });
+      return true;
+    }
+    bucket.count += 1;
+    return bucket.count <= config.limit;
+  }
+
+  clearSocket(socketId: string): void {
+    const prefix = `${socketId}:`;
+    for (const key of Array.from(this.buckets.keys())) {
+      if (key.startsWith(prefix)) {
+        this.buckets.delete(key);
+      }
+    }
+  }
+}

--- a/src/signaling/signaling-session.interface.ts
+++ b/src/signaling/signaling-session.interface.ts
@@ -1,10 +1,15 @@
-import { User } from '@prisma/client';
+import type { User } from '@prisma/client';
 
 export interface ParticipantInfo {
   socketId: string;
   userId: string;
   name: string;
   joinedAt: number;
+}
+
+export interface AddParticipantResult {
+  participant: ParticipantInfo;
+  evictedSocketId?: string;
 }
 
 export const SIGNALING_SESSION_SERVICE = Symbol('SIGNALING_SESSION_SERVICE');
@@ -14,13 +19,11 @@ export interface ISignalingSessionService {
     meetingId: string,
     socketId: string,
     user: Omit<User, 'passwordHash'>,
-  ): ParticipantInfo;
-
-  removeParticipant(meetingId: string, socketId: string): ParticipantInfo | undefined;
-
+  ): AddParticipantResult;
+  removeParticipant(
+    socketId: string,
+  ): { meetingId: string; participant: ParticipantInfo } | undefined;
   getParticipants(meetingId: string): ParticipantInfo[];
-
-  getSocketRooms(socketId: string): Set<string>;
-
+  getMeetingIdBySocket(socketId: string): string | undefined;
   isParticipant(meetingId: string, socketId: string): boolean;
 }

--- a/src/signaling/signaling-session.interface.ts
+++ b/src/signaling/signaling-session.interface.ts
@@ -1,0 +1,26 @@
+import { User } from '@prisma/client';
+
+export interface ParticipantInfo {
+  socketId: string;
+  userId: string;
+  name: string;
+  joinedAt: number;
+}
+
+export const SIGNALING_SESSION_SERVICE = Symbol('SIGNALING_SESSION_SERVICE');
+
+export interface ISignalingSessionService {
+  addParticipant(
+    meetingId: string,
+    socketId: string,
+    user: Omit<User, 'passwordHash'>,
+  ): ParticipantInfo;
+
+  removeParticipant(meetingId: string, socketId: string): ParticipantInfo | undefined;
+
+  getParticipants(meetingId: string): ParticipantInfo[];
+
+  getSocketRooms(socketId: string): Set<string>;
+
+  isParticipant(meetingId: string, socketId: string): boolean;
+}

--- a/src/signaling/signaling-session.service.spec.ts
+++ b/src/signaling/signaling-session.service.spec.ts
@@ -33,8 +33,8 @@ describe('SignalingSessionService', () => {
   // ── addParticipant ───────────────────────────────────────────────────
 
   describe('addParticipant', () => {
-    it('should return a ParticipantInfo with correct fields', () => {
-      const participant = service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+    it('should return a result with correct ParticipantInfo fields', () => {
+      const { participant } = service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
 
       expect(participant.socketId).toBe('socket-1');
       expect(participant.userId).toBe('user-1');
@@ -42,16 +42,19 @@ describe('SignalingSessionService', () => {
       expect(typeof participant.joinedAt).toBe('number');
     });
 
+    it('should return no evictedSocketId on fresh join', () => {
+      const { evictedSocketId } = service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+      expect(evictedSocketId).toBeUndefined();
+    });
+
     it('should make isParticipant return true after adding', () => {
       service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
-
       expect(service.isParticipant(MEETING_UUID, 'socket-1')).toBe(true);
     });
 
-    it('should register the meeting in getSocketRooms for the socket', () => {
+    it('should register the meeting in getMeetingIdBySocket for the socket', () => {
       service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
-
-      expect(service.getSocketRooms('socket-1').has(MEETING_UUID)).toBe(true);
+      expect(service.getMeetingIdBySocket('socket-1')).toBe(MEETING_UUID);
     });
 
     it('should track multiple sockets in the same room independently', () => {
@@ -62,13 +65,15 @@ describe('SignalingSessionService', () => {
       expect(service.isParticipant(MEETING_UUID, 'socket-2')).toBe(true);
     });
 
-    it('should track one socket across multiple rooms', () => {
-      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
-      service.addParticipant(MEETING_UUID_2, 'socket-1', fakeUser);
+    it('should evict the old socket when the same userId joins with a new socket', () => {
+      service.addParticipant(MEETING_UUID, 'socket-old', fakeUser);
+      const { evictedSocketId } = service.addParticipant(MEETING_UUID, 'socket-new', fakeUser);
 
-      const rooms = service.getSocketRooms('socket-1');
-      expect(rooms.has(MEETING_UUID)).toBe(true);
-      expect(rooms.has(MEETING_UUID_2)).toBe(true);
+      expect(evictedSocketId).toBe('socket-old');
+      expect(service.isParticipant(MEETING_UUID, 'socket-old')).toBe(false);
+      expect(service.isParticipant(MEETING_UUID, 'socket-new')).toBe(true);
+      expect(service.getMeetingIdBySocket('socket-old')).toBeUndefined();
+      expect(service.getMeetingIdBySocket('socket-new')).toBe(MEETING_UUID);
     });
   });
 
@@ -76,62 +81,45 @@ describe('SignalingSessionService', () => {
 
   describe('removeParticipant', () => {
     it('should return undefined for an unknown socketId', () => {
-      const result = service.removeParticipant(MEETING_UUID, 'ghost-socket');
+      const result = service.removeParticipant('ghost-socket');
       expect(result).toBeUndefined();
     });
 
-    it('should return undefined when meetingId does not exist', () => {
-      const result = service.removeParticipant('nonexistent-meeting', 'socket-1');
-      expect(result).toBeUndefined();
-    });
-
-    it('should return the removed ParticipantInfo', () => {
+    it('should return { meetingId, participant } on successful removal', () => {
       service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+      const result = service.removeParticipant('socket-1');
 
-      const removed = service.removeParticipant(MEETING_UUID, 'socket-1');
-
-      expect(removed).toBeDefined();
-      expect(removed!.socketId).toBe('socket-1');
-      expect(removed!.userId).toBe('user-1');
+      expect(result).toBeDefined();
+      expect(result!.meetingId).toBe(MEETING_UUID);
+      expect(result!.participant.socketId).toBe('socket-1');
+      expect(result!.participant.userId).toBe('user-1');
     });
 
     it('should make isParticipant return false after removing', () => {
       service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
-      service.removeParticipant(MEETING_UUID, 'socket-1');
+      service.removeParticipant('socket-1');
 
       expect(service.isParticipant(MEETING_UUID, 'socket-1')).toBe(false);
     });
 
     it('should clean up the room entry when the last participant leaves', () => {
       service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
-      service.removeParticipant(MEETING_UUID, 'socket-1');
+      service.removeParticipant('socket-1');
 
-      // Room entry gone — getParticipants returns empty array, not throws
       expect(service.getParticipants(MEETING_UUID)).toEqual([]);
     });
 
-    it('should remove the meeting from getSocketRooms when participant leaves', () => {
+    it('should clear getMeetingIdBySocket after removal', () => {
       service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
-      service.removeParticipant(MEETING_UUID, 'socket-1');
+      service.removeParticipant('socket-1');
 
-      expect(service.getSocketRooms('socket-1').has(MEETING_UUID)).toBe(false);
-    });
-
-    it('should not remove other rooms from getSocketRooms when leaving one room', () => {
-      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
-      service.addParticipant(MEETING_UUID_2, 'socket-1', fakeUser);
-
-      service.removeParticipant(MEETING_UUID, 'socket-1');
-
-      expect(service.getSocketRooms('socket-1').has(MEETING_UUID)).toBe(false);
-      expect(service.getSocketRooms('socket-1').has(MEETING_UUID_2)).toBe(true);
+      expect(service.getMeetingIdBySocket('socket-1')).toBeUndefined();
     });
 
     it('should not remove other participants when one leaves', () => {
       service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
       service.addParticipant(MEETING_UUID, 'socket-2', fakeUser2);
-
-      service.removeParticipant(MEETING_UUID, 'socket-1');
+      service.removeParticipant('socket-1');
 
       expect(service.isParticipant(MEETING_UUID, 'socket-2')).toBe(true);
     });
@@ -157,13 +145,16 @@ describe('SignalingSessionService', () => {
     });
   });
 
-  // ── getSocketRooms ────────────────────────────────────────────────────
+  // ── getMeetingIdBySocket ──────────────────────────────────────────────
 
-  describe('getSocketRooms', () => {
-    it('should return an empty Set for an unknown socket', () => {
-      const rooms = service.getSocketRooms('ghost-socket');
-      expect(rooms).toBeInstanceOf(Set);
-      expect(rooms.size).toBe(0);
+  describe('getMeetingIdBySocket', () => {
+    it('should return undefined for an unknown socket', () => {
+      expect(service.getMeetingIdBySocket('ghost-socket')).toBeUndefined();
+    });
+
+    it('should return the meeting id after joining', () => {
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+      expect(service.getMeetingIdBySocket('socket-1')).toBe(MEETING_UUID);
     });
   });
 

--- a/src/signaling/signaling-session.service.spec.ts
+++ b/src/signaling/signaling-session.service.spec.ts
@@ -1,0 +1,182 @@
+import { SignalingSessionService } from './signaling-session.service';
+
+const MEETING_UUID = '11111111-1111-4111-a111-111111111111';
+const MEETING_UUID_2 = '22222222-2222-4222-a222-222222222222';
+
+const fakeUser = {
+  id: 'user-1',
+  email: 'alice@test.com',
+  name: 'Alice',
+  passwordHash: 'hashed',
+  role: 'USER' as const,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const fakeUser2 = {
+  id: 'user-2',
+  email: 'bob@test.com',
+  name: 'Bob',
+  passwordHash: 'hashed',
+  role: 'USER' as const,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe('SignalingSessionService', () => {
+  let service: SignalingSessionService;
+
+  beforeEach(() => {
+    service = new SignalingSessionService();
+  });
+
+  // ── addParticipant ───────────────────────────────────────────────────
+
+  describe('addParticipant', () => {
+    it('should return a ParticipantInfo with correct fields', () => {
+      const participant = service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+
+      expect(participant.socketId).toBe('socket-1');
+      expect(participant.userId).toBe('user-1');
+      expect(participant.name).toBe('Alice');
+      expect(typeof participant.joinedAt).toBe('number');
+    });
+
+    it('should make isParticipant return true after adding', () => {
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+
+      expect(service.isParticipant(MEETING_UUID, 'socket-1')).toBe(true);
+    });
+
+    it('should register the meeting in getSocketRooms for the socket', () => {
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+
+      expect(service.getSocketRooms('socket-1').has(MEETING_UUID)).toBe(true);
+    });
+
+    it('should track multiple sockets in the same room independently', () => {
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+      service.addParticipant(MEETING_UUID, 'socket-2', fakeUser2);
+
+      expect(service.isParticipant(MEETING_UUID, 'socket-1')).toBe(true);
+      expect(service.isParticipant(MEETING_UUID, 'socket-2')).toBe(true);
+    });
+
+    it('should track one socket across multiple rooms', () => {
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+      service.addParticipant(MEETING_UUID_2, 'socket-1', fakeUser);
+
+      const rooms = service.getSocketRooms('socket-1');
+      expect(rooms.has(MEETING_UUID)).toBe(true);
+      expect(rooms.has(MEETING_UUID_2)).toBe(true);
+    });
+  });
+
+  // ── removeParticipant ────────────────────────────────────────────────
+
+  describe('removeParticipant', () => {
+    it('should return undefined for an unknown socketId', () => {
+      const result = service.removeParticipant(MEETING_UUID, 'ghost-socket');
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when meetingId does not exist', () => {
+      const result = service.removeParticipant('nonexistent-meeting', 'socket-1');
+      expect(result).toBeUndefined();
+    });
+
+    it('should return the removed ParticipantInfo', () => {
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+
+      const removed = service.removeParticipant(MEETING_UUID, 'socket-1');
+
+      expect(removed).toBeDefined();
+      expect(removed!.socketId).toBe('socket-1');
+      expect(removed!.userId).toBe('user-1');
+    });
+
+    it('should make isParticipant return false after removing', () => {
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+      service.removeParticipant(MEETING_UUID, 'socket-1');
+
+      expect(service.isParticipant(MEETING_UUID, 'socket-1')).toBe(false);
+    });
+
+    it('should clean up the room entry when the last participant leaves', () => {
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+      service.removeParticipant(MEETING_UUID, 'socket-1');
+
+      // Room entry gone — getParticipants returns empty array, not throws
+      expect(service.getParticipants(MEETING_UUID)).toEqual([]);
+    });
+
+    it('should remove the meeting from getSocketRooms when participant leaves', () => {
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+      service.removeParticipant(MEETING_UUID, 'socket-1');
+
+      expect(service.getSocketRooms('socket-1').has(MEETING_UUID)).toBe(false);
+    });
+
+    it('should not remove other rooms from getSocketRooms when leaving one room', () => {
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+      service.addParticipant(MEETING_UUID_2, 'socket-1', fakeUser);
+
+      service.removeParticipant(MEETING_UUID, 'socket-1');
+
+      expect(service.getSocketRooms('socket-1').has(MEETING_UUID)).toBe(false);
+      expect(service.getSocketRooms('socket-1').has(MEETING_UUID_2)).toBe(true);
+    });
+
+    it('should not remove other participants when one leaves', () => {
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+      service.addParticipant(MEETING_UUID, 'socket-2', fakeUser2);
+
+      service.removeParticipant(MEETING_UUID, 'socket-1');
+
+      expect(service.isParticipant(MEETING_UUID, 'socket-2')).toBe(true);
+    });
+  });
+
+  // ── getParticipants ──────────────────────────────────────────────────
+
+  describe('getParticipants', () => {
+    it('should return an empty array for a non-existent room', () => {
+      expect(service.getParticipants('no-such-room')).toEqual([]);
+    });
+
+    it('should return the correct participants after adding', () => {
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+      service.addParticipant(MEETING_UUID, 'socket-2', fakeUser2);
+
+      const participants = service.getParticipants(MEETING_UUID);
+
+      expect(participants).toHaveLength(2);
+      expect(participants.map((p) => p.userId)).toEqual(
+        expect.arrayContaining(['user-1', 'user-2']),
+      );
+    });
+  });
+
+  // ── getSocketRooms ────────────────────────────────────────────────────
+
+  describe('getSocketRooms', () => {
+    it('should return an empty Set for an unknown socket', () => {
+      const rooms = service.getSocketRooms('ghost-socket');
+      expect(rooms).toBeInstanceOf(Set);
+      expect(rooms.size).toBe(0);
+    });
+  });
+
+  // ── isParticipant ─────────────────────────────────────────────────────
+
+  describe('isParticipant', () => {
+    it('should return false for a non-existent room', () => {
+      expect(service.isParticipant('no-such-room', 'socket-1')).toBe(false);
+    });
+
+    it('should return false for a socket not in the room', () => {
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+      expect(service.isParticipant(MEETING_UUID, 'socket-99')).toBe(false);
+    });
+  });
+});

--- a/src/signaling/signaling-session.service.ts
+++ b/src/signaling/signaling-session.service.ts
@@ -1,0 +1,78 @@
+import { Injectable } from '@nestjs/common';
+import { User } from '@prisma/client';
+import { ISignalingSessionService, ParticipantInfo } from './signaling-session.interface';
+
+@Injectable()
+export class SignalingSessionService implements ISignalingSessionService {
+  /** meetingId → (socketId → ParticipantInfo) */
+  private readonly rooms = new Map<string, Map<string, ParticipantInfo>>();
+
+  /** socketId → Set<meetingId> (reverse index for O(k) disconnect cleanup) */
+  private readonly socketRooms = new Map<string, Set<string>>();
+
+  addParticipant(
+    meetingId: string,
+    socketId: string,
+    user: Omit<User, 'passwordHash'>,
+  ): ParticipantInfo {
+    if (!this.rooms.has(meetingId)) {
+      this.rooms.set(meetingId, new Map());
+    }
+
+    const participant: ParticipantInfo = {
+      socketId,
+      userId: user.id,
+      name: user.name ?? 'Anonymous',
+      joinedAt: Date.now(),
+    };
+
+    this.rooms.get(meetingId)!.set(socketId, participant);
+
+    // Maintain reverse index
+    if (!this.socketRooms.has(socketId)) {
+      this.socketRooms.set(socketId, new Set());
+    }
+    this.socketRooms.get(socketId)!.add(meetingId);
+
+    return participant;
+  }
+
+  removeParticipant(meetingId: string, socketId: string): ParticipantInfo | undefined {
+    const room = this.rooms.get(meetingId);
+    if (!room) return undefined;
+
+    const participant = room.get(socketId);
+    if (!participant) return undefined;
+
+    room.delete(socketId);
+
+    // Last-participant lifecycle rule: destroy the session entry
+    if (room.size === 0) {
+      this.rooms.delete(meetingId);
+    }
+
+    // Update reverse index
+    const socketMeetings = this.socketRooms.get(socketId);
+    if (socketMeetings) {
+      socketMeetings.delete(meetingId);
+      if (socketMeetings.size === 0) {
+        this.socketRooms.delete(socketId);
+      }
+    }
+
+    return participant;
+  }
+
+  getParticipants(meetingId: string): ParticipantInfo[] {
+    const room = this.rooms.get(meetingId);
+    return room ? Array.from(room.values()) : [];
+  }
+
+  getSocketRooms(socketId: string): Set<string> {
+    return this.socketRooms.get(socketId) ?? new Set();
+  }
+
+  isParticipant(meetingId: string, socketId: string): boolean {
+    return this.rooms.get(meetingId)?.has(socketId) ?? false;
+  }
+}

--- a/src/signaling/signaling-session.service.ts
+++ b/src/signaling/signaling-session.service.ts
@@ -1,22 +1,34 @@
 import { Injectable } from '@nestjs/common';
-import { User } from '@prisma/client';
-import { ISignalingSessionService, ParticipantInfo } from './signaling-session.interface';
+import type { User } from '@prisma/client';
+import {
+  AddParticipantResult,
+  ISignalingSessionService,
+  ParticipantInfo,
+} from './signaling-session.interface';
 
 @Injectable()
 export class SignalingSessionService implements ISignalingSessionService {
-  /** meetingId → (socketId → ParticipantInfo) */
   private readonly rooms = new Map<string, Map<string, ParticipantInfo>>();
-
-  /** socketId → Set<meetingId> (reverse index for O(k) disconnect cleanup) */
-  private readonly socketRooms = new Map<string, Set<string>>();
+  private readonly socketToMeeting = new Map<string, string>();
 
   addParticipant(
     meetingId: string,
     socketId: string,
     user: Omit<User, 'passwordHash'>,
-  ): ParticipantInfo {
+  ): AddParticipantResult {
     if (!this.rooms.has(meetingId)) {
       this.rooms.set(meetingId, new Map());
+    }
+    const room = this.rooms.get(meetingId)!;
+
+    let evictedSocketId: string | undefined;
+    for (const [existingSocketId, p] of room.entries()) {
+      if (p.userId === user.id && existingSocketId !== socketId) {
+        evictedSocketId = existingSocketId;
+        room.delete(existingSocketId);
+        this.socketToMeeting.delete(existingSocketId);
+        break;
+      }
     }
 
     const participant: ParticipantInfo = {
@@ -25,51 +37,31 @@ export class SignalingSessionService implements ISignalingSessionService {
       name: user.name ?? 'Anonymous',
       joinedAt: Date.now(),
     };
-
-    this.rooms.get(meetingId)!.set(socketId, participant);
-
-    // Maintain reverse index
-    if (!this.socketRooms.has(socketId)) {
-      this.socketRooms.set(socketId, new Set());
-    }
-    this.socketRooms.get(socketId)!.add(meetingId);
-
-    return participant;
+    room.set(socketId, participant);
+    this.socketToMeeting.set(socketId, meetingId);
+    return { participant, evictedSocketId };
   }
 
-  removeParticipant(meetingId: string, socketId: string): ParticipantInfo | undefined {
+  removeParticipant(
+    socketId: string,
+  ): { meetingId: string; participant: ParticipantInfo } | undefined {
+    const meetingId = this.socketToMeeting.get(socketId);
+    if (!meetingId) return undefined;
     const room = this.rooms.get(meetingId);
-    if (!room) return undefined;
-
-    const participant = room.get(socketId);
+    const participant = room?.get(socketId);
     if (!participant) return undefined;
-
-    room.delete(socketId);
-
-    // Last-participant lifecycle rule: destroy the session entry
-    if (room.size === 0) {
-      this.rooms.delete(meetingId);
-    }
-
-    // Update reverse index
-    const socketMeetings = this.socketRooms.get(socketId);
-    if (socketMeetings) {
-      socketMeetings.delete(meetingId);
-      if (socketMeetings.size === 0) {
-        this.socketRooms.delete(socketId);
-      }
-    }
-
-    return participant;
+    room!.delete(socketId);
+    this.socketToMeeting.delete(socketId);
+    if (room!.size === 0) this.rooms.delete(meetingId);
+    return { meetingId, participant };
   }
 
   getParticipants(meetingId: string): ParticipantInfo[] {
-    const room = this.rooms.get(meetingId);
-    return room ? Array.from(room.values()) : [];
+    return Array.from(this.rooms.get(meetingId)?.values() ?? []);
   }
 
-  getSocketRooms(socketId: string): Set<string> {
-    return this.socketRooms.get(socketId) ?? new Set();
+  getMeetingIdBySocket(socketId: string): string | undefined {
+    return this.socketToMeeting.get(socketId);
   }
 
   isParticipant(meetingId: string, socketId: string): boolean {

--- a/src/signaling/signaling.gateway.spec.ts
+++ b/src/signaling/signaling.gateway.spec.ts
@@ -4,6 +4,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { JwtService } from '@nestjs/jwt';
 import { SignalingGateway } from './signaling.gateway';
+import { SignalingRateLimiterService } from './signaling-rate-limiter.service';
 import { UsersRepository } from '../users/users.repository';
 import { MeetingsRepository } from '../meetings/meetings.repository';
 import { SIGNALING_SESSION_SERVICE } from './signaling-session.interface';
@@ -79,9 +80,10 @@ describe('SignalingGateway', () => {
     addParticipant: jest.Mock;
     removeParticipant: jest.Mock;
     getParticipants: jest.Mock;
-    getSocketRooms: jest.Mock;
+    getMeetingIdBySocket: jest.Mock;
     isParticipant: jest.Mock;
   };
+  let mockRateLimiter: { check: jest.Mock; clearSocket: jest.Mock };
   let mockServerToChain: { to: jest.Mock; emit: jest.Mock };
 
   beforeEach(async () => {
@@ -92,11 +94,15 @@ describe('SignalingGateway', () => {
     jwtService = { verify: jest.fn() };
     usersRepository = { findById: jest.fn() };
     mockSessionService = {
-      addParticipant: jest.fn().mockReturnValue(fakeParticipant),
+      addParticipant: jest.fn().mockReturnValue({ participant: fakeParticipant }),
       removeParticipant: jest.fn().mockReturnValue(undefined),
       getParticipants: jest.fn().mockReturnValue([]),
-      getSocketRooms: jest.fn().mockReturnValue(new Set<string>()),
+      getMeetingIdBySocket: jest.fn().mockReturnValue(undefined),
       isParticipant: jest.fn().mockReturnValue(false),
+    };
+    mockRateLimiter = {
+      check: jest.fn().mockReturnValue(true),
+      clearSocket: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -106,6 +112,7 @@ describe('SignalingGateway', () => {
         { provide: UsersRepository, useValue: usersRepository },
         { provide: MeetingsRepository, useValue: meetingsRepository },
         { provide: SIGNALING_SESSION_SERVICE, useValue: mockSessionService },
+        { provide: SignalingRateLimiterService, useValue: mockRateLimiter },
       ],
     }).compile();
 
@@ -115,8 +122,9 @@ describe('SignalingGateway', () => {
     const serverEmit = jest.fn();
     mockServerToChain = { to: jest.fn(), emit: serverEmit };
     mockServerToChain.to.mockReturnValue(mockServerToChain);
-    (gateway as unknown as { server: { to: jest.Mock } }).server = {
+    (gateway as unknown as { server: unknown }).server = {
       to: jest.fn().mockReturnValue(mockServerToChain),
+      sockets: { get: jest.fn().mockReturnValue(null) },
     };
   });
 
@@ -138,9 +146,7 @@ describe('SignalingGateway', () => {
 
     it('should disconnect with 401 when no token is provided', async () => {
       const socket = createConnectionSocket();
-
       await gateway.handleConnection(socket);
-
       expect(socket.emit).toHaveBeenCalledWith('error', {
         code: 401,
         message: 'Missing authentication token',
@@ -153,9 +159,7 @@ describe('SignalingGateway', () => {
       jwtService.verify.mockImplementation(() => {
         throw new Error('invalid signature');
       });
-
       await gateway.handleConnection(socket);
-
       expect(socket.emit).toHaveBeenCalledWith('error', {
         code: 401,
         message: 'invalid signature',
@@ -167,9 +171,7 @@ describe('SignalingGateway', () => {
       const socket = createConnectionSocket('valid-token');
       jwtService.verify.mockReturnValue({ userId: 'ghost-user' });
       usersRepository.findById.mockResolvedValue(null);
-
       await gateway.handleConnection(socket);
-
       expect(socket.emit).toHaveBeenCalledWith('error', {
         code: 401,
         message: 'User not found',
@@ -181,9 +183,7 @@ describe('SignalingGateway', () => {
       const socket = createConnectionSocket('valid-token');
       jwtService.verify.mockReturnValue({ userId: 'user-1' });
       usersRepository.findById.mockResolvedValue(fakeUser);
-
       await gateway.handleConnection(socket);
-
       expect(socket.emit).not.toHaveBeenCalled();
       expect(socket.disconnect).not.toHaveBeenCalled();
       const storedUser = socket.data.user as Record<string, unknown>;
@@ -199,9 +199,7 @@ describe('SignalingGateway', () => {
     it('should emit 401 when socket has no user', async () => {
       const socket = createMockSocket();
       socket.data.user = undefined;
-
       await gateway.handleJoinRoom({ meetingId: MEETING_UUID }, socket);
-
       expect(socket.emit).toHaveBeenCalledWith('error', {
         code: 401,
         message: 'Not authenticated',
@@ -211,9 +209,7 @@ describe('SignalingGateway', () => {
     it('should emit 400 when meetingId is not a valid UUID', async () => {
       const socket = createMockSocket();
       socket.data.user = fakeUser as never;
-
       await gateway.handleJoinRoom({ meetingId: 'bad-id' }, socket);
-
       expect(socket.emit).toHaveBeenCalledWith('error', expect.objectContaining({ code: 400 }));
     });
 
@@ -221,9 +217,7 @@ describe('SignalingGateway', () => {
       const socket = createMockSocket();
       socket.data.user = fakeUser as never;
       meetingsRepository.findById.mockResolvedValue(null);
-
       await gateway.handleJoinRoom({ meetingId: MEETING_UUID }, socket);
-
       expect(socket.emit).toHaveBeenCalledWith('error', {
         code: 404,
         message: 'Meeting ' + MEETING_UUID + ' not found',
@@ -235,9 +229,7 @@ describe('SignalingGateway', () => {
       socket.data.user = fakeUser as never;
       meetingsRepository.findById.mockResolvedValue({ id: MEETING_UUID });
       meetingsRepository.findMemberByMeetingAndUser.mockResolvedValue(null);
-
       await gateway.handleJoinRoom({ meetingId: MEETING_UUID }, socket);
-
       expect(socket.emit).toHaveBeenCalledWith('error', {
         code: 403,
         message: 'Not a member of this meeting',
@@ -250,9 +242,7 @@ describe('SignalingGateway', () => {
       meetingsRepository.findById.mockResolvedValue({ id: MEETING_UUID });
       meetingsRepository.findMemberByMeetingAndUser.mockResolvedValue({ id: 'member-1' });
       mockSessionService.isParticipant.mockReturnValue(true);
-
       await gateway.handleJoinRoom({ meetingId: MEETING_UUID }, socket);
-
       expect(socket.join).not.toHaveBeenCalled();
       expect(mockSessionService.addParticipant).not.toHaveBeenCalled();
     });
@@ -263,7 +253,7 @@ describe('SignalingGateway', () => {
       meetingsRepository.findById.mockResolvedValue({ id: MEETING_UUID });
       meetingsRepository.findMemberByMeetingAndUser.mockResolvedValue({ id: 'member-1' });
       mockSessionService.isParticipant.mockReturnValue(false);
-      mockSessionService.addParticipant.mockReturnValue(fakeParticipant);
+      mockSessionService.addParticipant.mockReturnValue({ participant: fakeParticipant });
       mockSessionService.getParticipants.mockReturnValue([fakeParticipant]);
 
       await gateway.handleJoinRoom({ meetingId: MEETING_UUID }, socket);
@@ -298,9 +288,7 @@ describe('SignalingGateway', () => {
     it('should emit 401 when socket has no user', () => {
       const socket = createMockSocket();
       socket.data.user = undefined;
-
       gateway.handleLeaveRoom({ meetingId: MEETING_UUID }, socket);
-
       expect(socket.emit).toHaveBeenCalledWith('error', {
         code: 401,
         message: 'Not authenticated',
@@ -310,26 +298,27 @@ describe('SignalingGateway', () => {
     it('should emit 400 when meetingId is not a valid UUID', () => {
       const socket = createMockSocket();
       socket.data.user = fakeUser as never;
-
       gateway.handleLeaveRoom({ meetingId: 'bad-id' }, socket);
-
       expect(socket.emit).toHaveBeenCalledWith('error', expect.objectContaining({ code: 400 }));
     });
 
     it('should do nothing if socket is not in the room', () => {
       const socket = createMockSocket();
       socket.data.user = fakeUser as never;
-      mockSessionService.removeParticipant.mockReturnValue(undefined);
-
+      mockSessionService.isParticipant.mockReturnValue(false);
       gateway.handleLeaveRoom({ meetingId: MEETING_UUID }, socket);
-
       expect(socket.leave).not.toHaveBeenCalled();
+      expect(mockSessionService.removeParticipant).not.toHaveBeenCalled();
     });
 
     it('should leave room and broadcast participant-left', () => {
       const socket = createMockSocket();
       socket.data.user = fakeUser as never;
-      mockSessionService.removeParticipant.mockReturnValue(fakeParticipant);
+      mockSessionService.isParticipant.mockReturnValue(true);
+      mockSessionService.removeParticipant.mockReturnValue({
+        meetingId: MEETING_UUID,
+        participant: fakeParticipant,
+      });
 
       const mockServer = gateway as unknown as { server: { to: jest.Mock } };
       mockServer.server.to.mockReturnValue(mockServerToChain);
@@ -354,9 +343,7 @@ describe('SignalingGateway', () => {
     it('should emit 401 when socket has no user', async () => {
       const socket = createMockSocket();
       socket.data.user = undefined;
-
       await gateway.handleWatchMeeting({ meetingId: MEETING_UUID }, socket);
-
       expect(socket.emit).toHaveBeenCalledWith('error', {
         code: 401,
         message: 'Not authenticated',
@@ -366,9 +353,7 @@ describe('SignalingGateway', () => {
     it('should emit 400 when meetingId is not a valid UUID', async () => {
       const socket = createMockSocket();
       socket.data.user = fakeUser as never;
-
       await gateway.handleWatchMeeting({ meetingId: 'not-a-uuid' }, socket);
-
       expect(socket.emit).toHaveBeenCalledWith('error', expect.objectContaining({ code: 400 }));
     });
 
@@ -376,9 +361,7 @@ describe('SignalingGateway', () => {
       const socket = createMockSocket();
       socket.data.user = fakeUser as never;
       meetingsRepository.findById.mockResolvedValue(null);
-
       await gateway.handleWatchMeeting({ meetingId: MEETING_UUID }, socket);
-
       expect(socket.emit).toHaveBeenCalledWith('error', {
         code: 404,
         message: 'Meeting ' + MEETING_UUID + ' not found',
@@ -390,9 +373,7 @@ describe('SignalingGateway', () => {
       socket.data.user = fakeUser as never;
       meetingsRepository.findById.mockResolvedValue({ id: MEETING_UUID });
       meetingsRepository.findMemberByMeetingAndUser.mockResolvedValue(null);
-
       await gateway.handleWatchMeeting({ meetingId: MEETING_UUID }, socket);
-
       expect(socket.emit).toHaveBeenCalledWith('error', {
         code: 403,
         message: 'Not a member of this meeting',
@@ -405,9 +386,7 @@ describe('SignalingGateway', () => {
       meetingsRepository.findById.mockResolvedValue({ id: MEETING_UUID });
       meetingsRepository.findMemberByMeetingAndUser.mockResolvedValue({ id: 'member-1' });
       mockSessionService.getParticipants.mockReturnValue([fakeParticipant]);
-
       await gateway.handleWatchMeeting({ meetingId: MEETING_UUID }, socket);
-
       expect(socket.join).toHaveBeenCalledWith('watch:' + MEETING_UUID);
       expect(socket.emit).toHaveBeenCalledWith('participants-list', {
         meetingId: MEETING_UUID,
@@ -419,7 +398,7 @@ describe('SignalingGateway', () => {
   // ── WebRTC relay: offer / answer / ice-candidate ───────────────────────
 
   describe('handleOffer / handleAnswer / handleIceCandidate', () => {
-    const relayPayload = { sdp: 'REDACTED' };
+    const relayPayload = { sdp: 'v=0' };
 
     function setupBothParticipants() {
       mockSessionService.isParticipant.mockReturnValueOnce(true).mockReturnValueOnce(true);
@@ -429,15 +408,12 @@ describe('SignalingGateway', () => {
       const sender = createMockSocket({ id: 'socket-1' });
       sender.data.user = fakeUser as never;
       setupBothParticipants();
-
       const mockServer = gateway as unknown as { server: { to: jest.Mock } };
       mockServer.server.to.mockReturnValue(mockServerToChain);
-
       gateway.handleOffer(
         { meetingId: MEETING_UUID, targetSocketId: TARGET_SOCKET_ID, payload: relayPayload },
         sender,
       );
-
       expect(mockServer.server.to).toHaveBeenCalledWith(TARGET_SOCKET_ID);
       expect(mockServerToChain.emit).toHaveBeenCalledWith('offer', {
         fromSocketId: 'socket-1',
@@ -449,15 +425,12 @@ describe('SignalingGateway', () => {
       const sender = createMockSocket({ id: 'socket-1' });
       sender.data.user = fakeUser as never;
       setupBothParticipants();
-
       const mockServer = gateway as unknown as { server: { to: jest.Mock } };
       mockServer.server.to.mockReturnValue(mockServerToChain);
-
       gateway.handleAnswer(
         { meetingId: MEETING_UUID, targetSocketId: TARGET_SOCKET_ID, payload: { sdp: 'answer' } },
         sender,
       );
-
       expect(mockServerToChain.emit).toHaveBeenCalledWith(
         'answer',
         expect.objectContaining({ fromSocketId: 'socket-1' }),
@@ -468,15 +441,12 @@ describe('SignalingGateway', () => {
       const sender = createMockSocket({ id: 'socket-1' });
       sender.data.user = fakeUser as never;
       setupBothParticipants();
-
       const mockServer = gateway as unknown as { server: { to: jest.Mock } };
       mockServer.server.to.mockReturnValue(mockServerToChain);
-
       gateway.handleIceCandidate(
         { meetingId: MEETING_UUID, targetSocketId: TARGET_SOCKET_ID, payload: { candidate: 'x' } },
         sender,
       );
-
       expect(mockServerToChain.emit).toHaveBeenCalledWith(
         'ice-candidate',
         expect.objectContaining({ fromSocketId: 'socket-1' }),
@@ -486,12 +456,10 @@ describe('SignalingGateway', () => {
     it('should emit 401 when sender is not authenticated', () => {
       const socket = createMockSocket();
       socket.data.user = undefined;
-
       gateway.handleOffer(
         { meetingId: MEETING_UUID, targetSocketId: TARGET_SOCKET_ID, payload: {} },
         socket,
       );
-
       expect(socket.emit).toHaveBeenCalledWith('error', {
         code: 401,
         message: 'Not authenticated',
@@ -501,21 +469,17 @@ describe('SignalingGateway', () => {
     it('should emit 400 when meetingId is not a valid UUID', () => {
       const socket = createMockSocket();
       socket.data.user = fakeUser as never;
-
       gateway.handleOffer(
         { meetingId: 'not-a-uuid', targetSocketId: TARGET_SOCKET_ID, payload: {} },
         socket,
       );
-
       expect(socket.emit).toHaveBeenCalledWith('error', expect.objectContaining({ code: 400 }));
     });
 
     it('should emit 400 when targetSocketId is empty', () => {
       const socket = createMockSocket();
       socket.data.user = fakeUser as never;
-
       gateway.handleOffer({ meetingId: MEETING_UUID, targetSocketId: '', payload: {} }, socket);
-
       expect(socket.emit).toHaveBeenCalledWith('error', expect.objectContaining({ code: 400 }));
     });
 
@@ -523,12 +487,10 @@ describe('SignalingGateway', () => {
       const socket = createMockSocket({ id: 'socket-not-in-room' });
       socket.data.user = fakeUser as never;
       mockSessionService.isParticipant.mockReturnValue(false);
-
       gateway.handleOffer(
         { meetingId: MEETING_UUID, targetSocketId: TARGET_SOCKET_ID, payload: {} },
         socket,
       );
-
       expect(socket.emit).toHaveBeenCalledWith('error', {
         code: 403,
         message: 'You are not in this room',
@@ -539,42 +501,27 @@ describe('SignalingGateway', () => {
       const socket = createMockSocket({ id: 'socket-1' });
       socket.data.user = fakeUser as never;
       mockSessionService.isParticipant.mockReturnValueOnce(true).mockReturnValueOnce(false);
-
       gateway.handleOffer(
         { meetingId: MEETING_UUID, targetSocketId: 'unknown-target', payload: {} },
         socket,
       );
-
       expect(socket.emit).toHaveBeenCalledWith('error', {
         code: 404,
         message: 'Target socket is not in this room',
       });
     });
 
-    it('should emit 429 when rate limit is exceeded (>30 per window)', () => {
+    it('should emit 429 when rate limiter blocks the event', () => {
       const socket = createMockSocket({ id: 'socket-rl' });
       socket.data.user = fakeUser as never;
-      mockSessionService.isParticipant.mockReturnValue(true);
-
-      const mockServer = gateway as unknown as { server: { to: jest.Mock } };
-      mockServer.server.to.mockReturnValue(mockServerToChain);
-
-      for (let i = 0; i < 30; i++) {
-        gateway.handleOffer(
-          { meetingId: MEETING_UUID, targetSocketId: TARGET_SOCKET_ID, payload: {} },
-          socket,
-        );
-      }
-
-      (socket.emit as jest.Mock).mockClear();
+      mockRateLimiter.check.mockReturnValue(false);
       gateway.handleOffer(
         { meetingId: MEETING_UUID, targetSocketId: TARGET_SOCKET_ID, payload: {} },
         socket,
       );
-
       expect(socket.emit).toHaveBeenCalledWith('error', {
         code: 429,
-        message: 'Rate limit exceeded for signaling events',
+        message: 'Too many signaling events',
       });
     });
   });
@@ -584,38 +531,42 @@ describe('SignalingGateway', () => {
   describe('handleDisconnect', () => {
     it('should produce no broadcasts when socket was in no rooms', () => {
       const socket = createMockSocket();
-      mockSessionService.getSocketRooms.mockReturnValue(new Set<string>());
+      mockSessionService.removeParticipant.mockReturnValue(undefined);
 
       gateway.handleDisconnect(socket);
 
       expect(mockServerToChain.emit).not.toHaveBeenCalled();
     });
 
-    it('should clean up all rooms the socket was registered in', () => {
+    it('should clean up the room the socket was registered in', () => {
       const socket = createMockSocket({ id: 'socket-1' });
       socket.data.user = fakeUser as never;
-      mockSessionService.getSocketRooms.mockReturnValue(
-        new Set<string>([MEETING_UUID, MEETING_UUID_2]),
-      );
-      mockSessionService.removeParticipant
-        .mockReturnValueOnce({ ...fakeParticipant, socketId: 'socket-1' })
-        .mockReturnValueOnce({ ...fakeParticipant2, socketId: 'socket-1' });
+      mockSessionService.removeParticipant.mockReturnValue({
+        meetingId: MEETING_UUID,
+        participant: fakeParticipant,
+      });
 
       const mockServer = gateway as unknown as { server: { to: jest.Mock } };
       mockServer.server.to.mockReturnValue(mockServerToChain);
 
       gateway.handleDisconnect(socket);
 
-      expect(mockSessionService.removeParticipant).toHaveBeenCalledTimes(2);
-      expect(mockServerToChain.emit).toHaveBeenCalledTimes(2);
+      expect(mockSessionService.removeParticipant).toHaveBeenCalledTimes(1);
+      expect(mockSessionService.removeParticipant).toHaveBeenCalledWith('socket-1');
+      expect(mockServerToChain.emit).toHaveBeenCalledTimes(1);
       expect(mockServerToChain.emit).toHaveBeenCalledWith(
         'participant-left',
         expect.objectContaining({ meetingId: MEETING_UUID }),
       );
-      expect(mockServerToChain.emit).toHaveBeenCalledWith(
-        'participant-left',
-        expect.objectContaining({ meetingId: MEETING_UUID_2 }),
-      );
+    });
+
+    it('should call rateLimiter.clearSocket on disconnect', () => {
+      const socket = createMockSocket({ id: 'socket-rl' });
+      socket.data.user = fakeUser as never;
+
+      gateway.handleDisconnect(socket);
+
+      expect(mockRateLimiter.clearSocket).toHaveBeenCalledWith('socket-rl');
     });
 
     it('should not throw after a rate-limited socket disconnects', () => {

--- a/src/signaling/signaling.gateway.spec.ts
+++ b/src/signaling/signaling.gateway.spec.ts
@@ -1,26 +1,48 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
 import { Test, TestingModule } from '@nestjs/testing';
 import { JwtService } from '@nestjs/jwt';
-import { SignalingGateway, ParticipantInfo } from './signaling.gateway';
+import { SignalingGateway } from './signaling.gateway';
 import { UsersRepository } from '../users/users.repository';
 import { MeetingsRepository } from '../meetings/meetings.repository';
+import { SIGNALING_SESSION_SERVICE } from './signaling-session.interface';
+import type { ParticipantInfo } from './signaling-session.interface';
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+const MEETING_UUID = '11111111-1111-4111-a111-111111111111';
+const MEETING_UUID_2 = '22222222-2222-4222-a222-222222222222';
+const TARGET_SOCKET_ID = 'socket-target';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
+/** Returns a chainable broadcast mock implementing .to().to().emit(). */
+function createBroadcastChain() {
+  const broadcastEmit = jest.fn();
+  const chain = { to: jest.fn(), emit: broadcastEmit };
+  chain.to.mockReturnValue(chain);
+  return chain;
+}
+
 function createMockSocket(overrides: Record<string, unknown> = {}) {
-  return {
-    id: 'socket-1',
-    data: { user: undefined as Record<string, unknown> | undefined },
-    handshake: { auth: {}, headers: {} },
-    emit: jest.fn(),
-    join: jest.fn(),
-    leave: jest.fn(),
-    disconnect: jest.fn(),
-    to: jest.fn().mockReturnThis(),
-    ...overrides,
-  } as unknown as Parameters<SignalingGateway['handleJoinRoom']>[1];
+  const broadcastChain = createBroadcastChain();
+  return Object.assign(
+    {
+      id: 'socket-1',
+      data: { user: undefined as Record<string, unknown> | undefined },
+      handshake: { auth: {}, headers: {} },
+      emit: jest.fn(),
+      join: jest.fn(),
+      leave: jest.fn(),
+      disconnect: jest.fn(),
+      to: jest.fn().mockReturnValue(broadcastChain),
+    },
+    { _broadcast: broadcastChain },
+    overrides,
+  ) as unknown as Parameters<SignalingGateway['handleJoinRoom']>[1] & {
+    _broadcast: ReturnType<typeof createBroadcastChain>;
+  };
 }
 
 const fakeUser = {
@@ -32,15 +54,18 @@ const fakeUser = {
   createdAt: new Date(),
   updatedAt: new Date(),
 };
+const fakeParticipant: ParticipantInfo = {
+  socketId: 'socket-1',
+  userId: 'user-1',
+  name: 'Alice',
+  joinedAt: 0,
+};
 
-const fakeUser2 = {
-  id: 'user-2',
-  email: 'bob@test.com',
+const fakeParticipant2: ParticipantInfo = {
+  socketId: 'socket-2',
+  userId: 'user-2',
   name: 'Bob',
-  passwordHash: 'hashed',
-  role: 'USER' as const,
-  createdAt: new Date(),
-  updatedAt: new Date(),
+  joinedAt: 0,
 };
 
 // ── Test suite ─────────────────────────────────────────────────────────────
@@ -50,6 +75,14 @@ describe('SignalingGateway', () => {
   let meetingsRepository: { findById: jest.Mock; findMemberByMeetingAndUser: jest.Mock };
   let jwtService: { verify: jest.Mock };
   let usersRepository: { findById: jest.Mock };
+  let mockSessionService: {
+    addParticipant: jest.Mock;
+    removeParticipant: jest.Mock;
+    getParticipants: jest.Mock;
+    getSocketRooms: jest.Mock;
+    isParticipant: jest.Mock;
+  };
+  let mockServerToChain: { to: jest.Mock; emit: jest.Mock };
 
   beforeEach(async () => {
     meetingsRepository = {
@@ -58,6 +91,13 @@ describe('SignalingGateway', () => {
     };
     jwtService = { verify: jest.fn() };
     usersRepository = { findById: jest.fn() };
+    mockSessionService = {
+      addParticipant: jest.fn().mockReturnValue(fakeParticipant),
+      removeParticipant: jest.fn().mockReturnValue(undefined),
+      getParticipants: jest.fn().mockReturnValue([]),
+      getSocketRooms: jest.fn().mockReturnValue(new Set<string>()),
+      isParticipant: jest.fn().mockReturnValue(false),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -65,14 +105,18 @@ describe('SignalingGateway', () => {
         { provide: JwtService, useValue: jwtService },
         { provide: UsersRepository, useValue: usersRepository },
         { provide: MeetingsRepository, useValue: meetingsRepository },
+        { provide: SIGNALING_SESSION_SERVICE, useValue: mockSessionService },
       ],
     }).compile();
 
     gateway = module.get<SignalingGateway>(SignalingGateway);
 
     // Provide a mock server for broadcast operations
+    const serverEmit = jest.fn();
+    mockServerToChain = { to: jest.fn(), emit: serverEmit };
+    mockServerToChain.to.mockReturnValue(mockServerToChain);
     (gateway as unknown as { server: { to: jest.Mock } }).server = {
-      to: jest.fn().mockReturnValue({ emit: jest.fn() }),
+      to: jest.fn().mockReturnValue(mockServerToChain),
     };
   });
 
@@ -156,7 +200,7 @@ describe('SignalingGateway', () => {
       const socket = createMockSocket();
       socket.data.user = undefined;
 
-      await gateway.handleJoinRoom({ meetingId: 'meeting-1' }, socket);
+      await gateway.handleJoinRoom({ meetingId: MEETING_UUID }, socket);
 
       expect(socket.emit).toHaveBeenCalledWith('error', {
         code: 401,
@@ -164,26 +208,35 @@ describe('SignalingGateway', () => {
       });
     });
 
+    it('should emit 400 when meetingId is not a valid UUID', async () => {
+      const socket = createMockSocket();
+      socket.data.user = fakeUser as never;
+
+      await gateway.handleJoinRoom({ meetingId: 'bad-id' }, socket);
+
+      expect(socket.emit).toHaveBeenCalledWith('error', expect.objectContaining({ code: 400 }));
+    });
+
     it('should emit 404 when meeting does not exist', async () => {
       const socket = createMockSocket();
       socket.data.user = fakeUser as never;
       meetingsRepository.findById.mockResolvedValue(null);
 
-      await gateway.handleJoinRoom({ meetingId: 'bad-id' }, socket);
+      await gateway.handleJoinRoom({ meetingId: MEETING_UUID }, socket);
 
       expect(socket.emit).toHaveBeenCalledWith('error', {
         code: 404,
-        message: 'Meeting bad-id not found',
+        message: 'Meeting ' + MEETING_UUID + ' not found',
       });
     });
 
     it('should emit 403 when user is not a member', async () => {
       const socket = createMockSocket();
       socket.data.user = fakeUser as never;
-      meetingsRepository.findById.mockResolvedValue({ id: 'meeting-1' });
+      meetingsRepository.findById.mockResolvedValue({ id: MEETING_UUID });
       meetingsRepository.findMemberByMeetingAndUser.mockResolvedValue(null);
 
-      await gateway.handleJoinRoom({ meetingId: 'meeting-1' }, socket);
+      await gateway.handleJoinRoom({ meetingId: MEETING_UUID }, socket);
 
       expect(socket.emit).toHaveBeenCalledWith('error', {
         code: 403,
@@ -191,28 +244,49 @@ describe('SignalingGateway', () => {
       });
     });
 
-    it('should join room, add to presence, and broadcast', async () => {
+    it('should be a no-op when socket is already in the room', async () => {
       const socket = createMockSocket();
       socket.data.user = fakeUser as never;
-      meetingsRepository.findById.mockResolvedValue({ id: 'meeting-1' });
+      meetingsRepository.findById.mockResolvedValue({ id: MEETING_UUID });
       meetingsRepository.findMemberByMeetingAndUser.mockResolvedValue({ id: 'member-1' });
+      mockSessionService.isParticipant.mockReturnValue(true);
 
-      const toEmit = jest.fn();
-      (socket.to as jest.Mock).mockReturnValue({ emit: toEmit });
+      await gateway.handleJoinRoom({ meetingId: MEETING_UUID }, socket);
 
-      await gateway.handleJoinRoom({ meetingId: 'meeting-1' }, socket);
+      expect(socket.join).not.toHaveBeenCalled();
+      expect(mockSessionService.addParticipant).not.toHaveBeenCalled();
+    });
 
-      expect(socket.join).toHaveBeenCalledWith('meeting-1');
-      expect(socket.to).toHaveBeenCalledWith('meeting-1');
-      expect(toEmit).toHaveBeenCalledWith(
+    it('should join room, call addParticipant, broadcast, and emit participants-list', async () => {
+      const socket = createMockSocket();
+      socket.data.user = fakeUser as never;
+      meetingsRepository.findById.mockResolvedValue({ id: MEETING_UUID });
+      meetingsRepository.findMemberByMeetingAndUser.mockResolvedValue({ id: 'member-1' });
+      mockSessionService.isParticipant.mockReturnValue(false);
+      mockSessionService.addParticipant.mockReturnValue(fakeParticipant);
+      mockSessionService.getParticipants.mockReturnValue([fakeParticipant]);
+
+      await gateway.handleJoinRoom({ meetingId: MEETING_UUID }, socket);
+
+      expect(socket.join).toHaveBeenCalledWith(MEETING_UUID);
+      expect(mockSessionService.addParticipant).toHaveBeenCalledWith(
+        MEETING_UUID,
+        'socket-1',
+        expect.objectContaining({ id: 'user-1' }),
+      );
+      expect(socket.to).toHaveBeenCalledWith(MEETING_UUID);
+      expect(socket._broadcast.emit).toHaveBeenCalledWith(
         'participant-joined',
         expect.objectContaining({
-          meetingId: 'meeting-1',
-          participant: expect.objectContaining({
-            userId: 'user-1',
-            name: 'Alice',
-            socketId: 'socket-1',
-          }),
+          meetingId: MEETING_UUID,
+          participant: expect.objectContaining({ userId: 'user-1', name: 'Alice' }),
+        }),
+      );
+      expect(socket.emit).toHaveBeenCalledWith(
+        'participants-list',
+        expect.objectContaining({
+          meetingId: MEETING_UUID,
+          participants: [fakeParticipant],
         }),
       );
     });
@@ -221,49 +295,11 @@ describe('SignalingGateway', () => {
   // ── leave-room ─────────────────────────────────────────────────────────
 
   describe('handleLeaveRoom', () => {
-    it('should do nothing if socket is not in the room', () => {
-      const socket = createMockSocket();
-      gateway.handleLeaveRoom({ meetingId: 'meeting-1' }, socket);
-
-      expect(socket.leave).not.toHaveBeenCalled();
-    });
-
-    it('should remove from room and broadcast participant-left', async () => {
-      // First join
-      const socket = createMockSocket();
-      socket.data.user = fakeUser as never;
-      meetingsRepository.findById.mockResolvedValue({ id: 'meeting-1' });
-      meetingsRepository.findMemberByMeetingAndUser.mockResolvedValue({ id: 'member-1' });
-      (socket.to as jest.Mock).mockReturnValue({ emit: jest.fn() });
-      await gateway.handleJoinRoom({ meetingId: 'meeting-1' }, socket);
-
-      // Then leave
-      const mockServer = gateway as unknown as { server: { to: jest.Mock } };
-      const serverEmit = jest.fn();
-      mockServer.server.to.mockReturnValue({ emit: serverEmit });
-
-      gateway.handleLeaveRoom({ meetingId: 'meeting-1' }, socket);
-
-      expect(socket.leave).toHaveBeenCalledWith('meeting-1');
-      expect(mockServer.server.to).toHaveBeenCalledWith('meeting-1');
-      expect(serverEmit).toHaveBeenCalledWith(
-        'participant-left',
-        expect.objectContaining({
-          meetingId: 'meeting-1',
-          participant: expect.objectContaining({ userId: 'user-1' }),
-        }),
-      );
-    });
-  });
-
-  // ── get-participants ───────────────────────────────────────────────────
-
-  describe('handleGetParticipants', () => {
-    it('should emit 401 when socket has no user', async () => {
+    it('should emit 401 when socket has no user', () => {
       const socket = createMockSocket();
       socket.data.user = undefined;
 
-      await gateway.handleGetParticipants({ meetingId: 'meeting-1' }, socket);
+      gateway.handleLeaveRoom({ meetingId: MEETING_UUID }, socket);
 
       expect(socket.emit).toHaveBeenCalledWith('error', {
         code: 401,
@@ -271,12 +307,91 @@ describe('SignalingGateway', () => {
       });
     });
 
-    it('should emit 403 when user is not a member', async () => {
+    it('should emit 400 when meetingId is not a valid UUID', () => {
       const socket = createMockSocket();
       socket.data.user = fakeUser as never;
+
+      gateway.handleLeaveRoom({ meetingId: 'bad-id' }, socket);
+
+      expect(socket.emit).toHaveBeenCalledWith('error', expect.objectContaining({ code: 400 }));
+    });
+
+    it('should do nothing if socket is not in the room', () => {
+      const socket = createMockSocket();
+      socket.data.user = fakeUser as never;
+      mockSessionService.removeParticipant.mockReturnValue(undefined);
+
+      gateway.handleLeaveRoom({ meetingId: MEETING_UUID }, socket);
+
+      expect(socket.leave).not.toHaveBeenCalled();
+    });
+
+    it('should leave room and broadcast participant-left', () => {
+      const socket = createMockSocket();
+      socket.data.user = fakeUser as never;
+      mockSessionService.removeParticipant.mockReturnValue(fakeParticipant);
+
+      const mockServer = gateway as unknown as { server: { to: jest.Mock } };
+      mockServer.server.to.mockReturnValue(mockServerToChain);
+
+      gateway.handleLeaveRoom({ meetingId: MEETING_UUID }, socket);
+
+      expect(socket.leave).toHaveBeenCalledWith(MEETING_UUID);
+      expect(mockServer.server.to).toHaveBeenCalledWith(MEETING_UUID);
+      expect(mockServerToChain.emit).toHaveBeenCalledWith(
+        'participant-left',
+        expect.objectContaining({
+          meetingId: MEETING_UUID,
+          participant: expect.objectContaining({ userId: 'user-1' }),
+        }),
+      );
+    });
+  });
+
+  // ── watch-meeting ──────────────────────────────────────────────────────
+
+  describe('handleWatchMeeting', () => {
+    it('should emit 401 when socket has no user', async () => {
+      const socket = createMockSocket();
+      socket.data.user = undefined;
+
+      await gateway.handleWatchMeeting({ meetingId: MEETING_UUID }, socket);
+
+      expect(socket.emit).toHaveBeenCalledWith('error', {
+        code: 401,
+        message: 'Not authenticated',
+      });
+    });
+
+    it('should emit 400 when meetingId is not a valid UUID', async () => {
+      const socket = createMockSocket();
+      socket.data.user = fakeUser as never;
+
+      await gateway.handleWatchMeeting({ meetingId: 'not-a-uuid' }, socket);
+
+      expect(socket.emit).toHaveBeenCalledWith('error', expect.objectContaining({ code: 400 }));
+    });
+
+    it('should emit 404 when meeting does not exist', async () => {
+      const socket = createMockSocket();
+      socket.data.user = fakeUser as never;
+      meetingsRepository.findById.mockResolvedValue(null);
+
+      await gateway.handleWatchMeeting({ meetingId: MEETING_UUID }, socket);
+
+      expect(socket.emit).toHaveBeenCalledWith('error', {
+        code: 404,
+        message: 'Meeting ' + MEETING_UUID + ' not found',
+      });
+    });
+
+    it('should emit 403 when user is not a member of the meeting', async () => {
+      const socket = createMockSocket();
+      socket.data.user = fakeUser as never;
+      meetingsRepository.findById.mockResolvedValue({ id: MEETING_UUID });
       meetingsRepository.findMemberByMeetingAndUser.mockResolvedValue(null);
 
-      await gateway.handleGetParticipants({ meetingId: 'meeting-1' }, socket);
+      await gateway.handleWatchMeeting({ meetingId: MEETING_UUID }, socket);
 
       expect(socket.emit).toHaveBeenCalledWith('error', {
         code: 403,
@@ -284,126 +399,98 @@ describe('SignalingGateway', () => {
       });
     });
 
-    it('should return the participant list for the room', async () => {
-      // Join first
+    it('should join watch room and emit current participants-list on success', async () => {
       const socket = createMockSocket();
       socket.data.user = fakeUser as never;
-      meetingsRepository.findById.mockResolvedValue({ id: 'meeting-1' });
+      meetingsRepository.findById.mockResolvedValue({ id: MEETING_UUID });
       meetingsRepository.findMemberByMeetingAndUser.mockResolvedValue({ id: 'member-1' });
-      (socket.to as jest.Mock).mockReturnValue({ emit: jest.fn() });
-      await gateway.handleJoinRoom({ meetingId: 'meeting-1' }, socket);
+      mockSessionService.getParticipants.mockReturnValue([fakeParticipant]);
 
-      // Get participants
-      (socket.emit as jest.Mock).mockClear();
-      await gateway.handleGetParticipants({ meetingId: 'meeting-1' }, socket);
+      await gateway.handleWatchMeeting({ meetingId: MEETING_UUID }, socket);
 
-      expect(socket.emit).toHaveBeenCalledWith(
-        'participants-list',
-        expect.objectContaining({
-          meetingId: 'meeting-1',
-          participants: expect.arrayContaining([
-            expect.objectContaining({ userId: 'user-1', name: 'Alice' }),
-          ]),
-        }),
-      );
-    });
-
-    it('should return empty list for a room with no participants', async () => {
-      const socket = createMockSocket();
-      socket.data.user = fakeUser as never;
-      meetingsRepository.findMemberByMeetingAndUser.mockResolvedValue({ id: 'member-1' });
-
-      await gateway.handleGetParticipants({ meetingId: 'meeting-1' }, socket);
-
+      expect(socket.join).toHaveBeenCalledWith('watch:' + MEETING_UUID);
       expect(socket.emit).toHaveBeenCalledWith('participants-list', {
-        meetingId: 'meeting-1',
-        participants: [],
+        meetingId: MEETING_UUID,
+        participants: [fakeParticipant],
       });
     });
   });
 
-  describe('handleWebRtcOffer / handleWebRtcAnswer / handleWebRtcIceCandidate', () => {
-    const meetingId = 'meeting-1';
-    const targetSocketId = 'socket-target';
+  // ── WebRTC relay: offer / answer / ice-candidate ───────────────────────
 
-    async function setupSenderAndTarget() {
-      // Sender joins the room
-      const sender = createMockSocket({ id: 'socket-1' });
-      sender.data.user = fakeUser as never;
-      meetingsRepository.findById.mockResolvedValue({ id: meetingId });
-      meetingsRepository.findMemberByMeetingAndUser.mockResolvedValue({ id: 'member-1' });
-      (sender.to as jest.Mock).mockReturnValue({ emit: jest.fn() });
-      await gateway.handleJoinRoom({ meetingId }, sender);
+  describe('handleOffer / handleAnswer / handleIceCandidate', () => {
+    const relayPayload = { sdp: 'REDACTED' };
 
-      // Target joins the room
-      const target = createMockSocket({ id: targetSocketId });
-      target.data.user = fakeUser2 as never;
-      meetingsRepository.findMemberByMeetingAndUser.mockResolvedValue({ id: 'member-2' });
-      (target.to as jest.Mock).mockReturnValue({ emit: jest.fn() });
-      await gateway.handleJoinRoom({ meetingId }, target);
-
-      return { sender, target };
+    function setupBothParticipants() {
+      mockSessionService.isParticipant.mockReturnValueOnce(true).mockReturnValueOnce(true);
     }
 
-    it('should relay webrtc-offer to the target socket', async () => {
-      const { sender } = await setupSenderAndTarget();
+    it('should relay offer to the target socket', () => {
+      const sender = createMockSocket({ id: 'socket-1' });
+      sender.data.user = fakeUser as never;
+      setupBothParticipants();
 
-      const serverEmit = jest.fn();
       const mockServer = gateway as unknown as { server: { to: jest.Mock } };
-      mockServer.server.to.mockReturnValue({ emit: serverEmit });
+      mockServer.server.to.mockReturnValue(mockServerToChain);
 
-      gateway.handleWebRtcOffer(
-        { meetingId, targetSocketId, payload: { sdp: 'REDACTED' } },
+      gateway.handleOffer(
+        { meetingId: MEETING_UUID, targetSocketId: TARGET_SOCKET_ID, payload: relayPayload },
         sender,
       );
 
-      expect(mockServer.server.to).toHaveBeenCalledWith(targetSocketId);
-      expect(serverEmit).toHaveBeenCalledWith('webrtc-offer', {
+      expect(mockServer.server.to).toHaveBeenCalledWith(TARGET_SOCKET_ID);
+      expect(mockServerToChain.emit).toHaveBeenCalledWith('offer', {
         fromSocketId: 'socket-1',
-        payload: { sdp: 'REDACTED' },
+        payload: relayPayload,
       });
     });
 
-    it('should relay webrtc-answer to the target socket', async () => {
-      const { sender } = await setupSenderAndTarget();
+    it('should relay answer to the target socket', () => {
+      const sender = createMockSocket({ id: 'socket-1' });
+      sender.data.user = fakeUser as never;
+      setupBothParticipants();
 
-      const serverEmit = jest.fn();
       const mockServer = gateway as unknown as { server: { to: jest.Mock } };
-      mockServer.server.to.mockReturnValue({ emit: serverEmit });
+      mockServer.server.to.mockReturnValue(mockServerToChain);
 
-      gateway.handleWebRtcAnswer({ meetingId, targetSocketId, payload: { sdp: 'answer' } }, sender);
-
-      expect(mockServer.server.to).toHaveBeenCalledWith(targetSocketId);
-      expect(serverEmit).toHaveBeenCalledWith('webrtc-answer', {
-        fromSocketId: 'socket-1',
-        payload: { sdp: 'answer' },
-      });
-    });
-
-    it('should relay webrtc-ice-candidate to the target socket', async () => {
-      const { sender } = await setupSenderAndTarget();
-
-      const serverEmit = jest.fn();
-      const mockServer = gateway as unknown as { server: { to: jest.Mock } };
-      mockServer.server.to.mockReturnValue({ emit: serverEmit });
-
-      gateway.handleWebRtcIceCandidate(
-        { meetingId, targetSocketId, payload: { candidate: 'REDACTED' } },
+      gateway.handleAnswer(
+        { meetingId: MEETING_UUID, targetSocketId: TARGET_SOCKET_ID, payload: { sdp: 'answer' } },
         sender,
       );
 
-      expect(mockServer.server.to).toHaveBeenCalledWith(targetSocketId);
-      expect(serverEmit).toHaveBeenCalledWith('webrtc-ice-candidate', {
-        fromSocketId: 'socket-1',
-        payload: { candidate: 'REDACTED' },
-      });
+      expect(mockServerToChain.emit).toHaveBeenCalledWith(
+        'answer',
+        expect.objectContaining({ fromSocketId: 'socket-1' }),
+      );
+    });
+
+    it('should relay ice-candidate to the target socket', () => {
+      const sender = createMockSocket({ id: 'socket-1' });
+      sender.data.user = fakeUser as never;
+      setupBothParticipants();
+
+      const mockServer = gateway as unknown as { server: { to: jest.Mock } };
+      mockServer.server.to.mockReturnValue(mockServerToChain);
+
+      gateway.handleIceCandidate(
+        { meetingId: MEETING_UUID, targetSocketId: TARGET_SOCKET_ID, payload: { candidate: 'x' } },
+        sender,
+      );
+
+      expect(mockServerToChain.emit).toHaveBeenCalledWith(
+        'ice-candidate',
+        expect.objectContaining({ fromSocketId: 'socket-1' }),
+      );
     });
 
     it('should emit 401 when sender is not authenticated', () => {
       const socket = createMockSocket();
       socket.data.user = undefined;
 
-      gateway.handleWebRtcOffer({ meetingId, targetSocketId, payload: {} }, socket);
+      gateway.handleOffer(
+        { meetingId: MEETING_UUID, targetSocketId: TARGET_SOCKET_ID, payload: {} },
+        socket,
+      );
 
       expect(socket.emit).toHaveBeenCalledWith('error', {
         code: 401,
@@ -411,35 +498,36 @@ describe('SignalingGateway', () => {
       });
     });
 
-    it('should emit 400 when meetingId is missing', () => {
+    it('should emit 400 when meetingId is not a valid UUID', () => {
       const socket = createMockSocket();
       socket.data.user = fakeUser as never;
 
-      gateway.handleWebRtcOffer({ meetingId: '', targetSocketId, payload: {} }, socket);
+      gateway.handleOffer(
+        { meetingId: 'not-a-uuid', targetSocketId: TARGET_SOCKET_ID, payload: {} },
+        socket,
+      );
 
-      expect(socket.emit).toHaveBeenCalledWith('error', {
-        code: 400,
-        message: 'meetingId and targetSocketId are required',
-      });
+      expect(socket.emit).toHaveBeenCalledWith('error', expect.objectContaining({ code: 400 }));
     });
 
-    it('should emit 400 when targetSocketId is missing', () => {
+    it('should emit 400 when targetSocketId is empty', () => {
       const socket = createMockSocket();
       socket.data.user = fakeUser as never;
 
-      gateway.handleWebRtcOffer({ meetingId, targetSocketId: '', payload: {} }, socket);
+      gateway.handleOffer({ meetingId: MEETING_UUID, targetSocketId: '', payload: {} }, socket);
 
-      expect(socket.emit).toHaveBeenCalledWith('error', {
-        code: 400,
-        message: 'meetingId and targetSocketId are required',
-      });
+      expect(socket.emit).toHaveBeenCalledWith('error', expect.objectContaining({ code: 400 }));
     });
 
     it('should emit 403 when sender is not in the room', () => {
       const socket = createMockSocket({ id: 'socket-not-in-room' });
       socket.data.user = fakeUser as never;
+      mockSessionService.isParticipant.mockReturnValue(false);
 
-      gateway.handleWebRtcOffer({ meetingId, targetSocketId, payload: {} }, socket);
+      gateway.handleOffer(
+        { meetingId: MEETING_UUID, targetSocketId: TARGET_SOCKET_ID, payload: {} },
+        socket,
+      );
 
       expect(socket.emit).toHaveBeenCalledWith('error', {
         code: 403,
@@ -447,17 +535,13 @@ describe('SignalingGateway', () => {
       });
     });
 
-    it('should emit 404 when target is not in the room', async () => {
-      // Only sender joins
+    it('should emit 404 when target is not in the room', () => {
       const socket = createMockSocket({ id: 'socket-1' });
       socket.data.user = fakeUser as never;
-      meetingsRepository.findById.mockResolvedValue({ id: meetingId });
-      meetingsRepository.findMemberByMeetingAndUser.mockResolvedValue({ id: 'member-1' });
-      (socket.to as jest.Mock).mockReturnValue({ emit: jest.fn() });
-      await gateway.handleJoinRoom({ meetingId }, socket);
+      mockSessionService.isParticipant.mockReturnValueOnce(true).mockReturnValueOnce(false);
 
-      gateway.handleWebRtcOffer(
-        { meetingId, targetSocketId: 'socket-not-in-room', payload: {} },
+      gateway.handleOffer(
+        { meetingId: MEETING_UUID, targetSocketId: 'unknown-target', payload: {} },
         socket,
       );
 
@@ -466,80 +550,88 @@ describe('SignalingGateway', () => {
         message: 'Target socket is not in this room',
       });
     });
+
+    it('should emit 429 when rate limit is exceeded (>30 per window)', () => {
+      const socket = createMockSocket({ id: 'socket-rl' });
+      socket.data.user = fakeUser as never;
+      mockSessionService.isParticipant.mockReturnValue(true);
+
+      const mockServer = gateway as unknown as { server: { to: jest.Mock } };
+      mockServer.server.to.mockReturnValue(mockServerToChain);
+
+      for (let i = 0; i < 30; i++) {
+        gateway.handleOffer(
+          { meetingId: MEETING_UUID, targetSocketId: TARGET_SOCKET_ID, payload: {} },
+          socket,
+        );
+      }
+
+      (socket.emit as jest.Mock).mockClear();
+      gateway.handleOffer(
+        { meetingId: MEETING_UUID, targetSocketId: TARGET_SOCKET_ID, payload: {} },
+        socket,
+      );
+
+      expect(socket.emit).toHaveBeenCalledWith('error', {
+        code: 429,
+        message: 'Rate limit exceeded for signaling events',
+      });
+    });
   });
 
-  // ── disconnect cleanup ─────────────────────────────────────────────────
+  // ── handleDisconnect ───────────────────────────────────────────────────
 
   describe('handleDisconnect', () => {
-    it('should produce no errors or broadcasts when socket was in no rooms', () => {
+    it('should produce no broadcasts when socket was in no rooms', () => {
       const socket = createMockSocket();
-      const mockServer = gateway as unknown as { server: { to: jest.Mock } };
+      mockSessionService.getSocketRooms.mockReturnValue(new Set<string>());
 
       gateway.handleDisconnect(socket);
 
-      expect(mockServer.server.to).not.toHaveBeenCalled();
-      expect(socket.emit).not.toHaveBeenCalled();
+      expect(mockServerToChain.emit).not.toHaveBeenCalled();
     });
 
-    it('should clean up all rooms the socket was in', async () => {
-      // Join two rooms
-      const socket = createMockSocket();
+    it('should clean up all rooms the socket was registered in', () => {
+      const socket = createMockSocket({ id: 'socket-1' });
       socket.data.user = fakeUser as never;
-      meetingsRepository.findById.mockResolvedValue({ id: 'meeting-1' });
-      meetingsRepository.findMemberByMeetingAndUser.mockResolvedValue({ id: 'member-1' });
-      (socket.to as jest.Mock).mockReturnValue({ emit: jest.fn() });
-      await gateway.handleJoinRoom({ meetingId: 'meeting-1' }, socket);
+      mockSessionService.getSocketRooms.mockReturnValue(
+        new Set<string>([MEETING_UUID, MEETING_UUID_2]),
+      );
+      mockSessionService.removeParticipant
+        .mockReturnValueOnce({ ...fakeParticipant, socketId: 'socket-1' })
+        .mockReturnValueOnce({ ...fakeParticipant2, socketId: 'socket-1' });
 
-      meetingsRepository.findById.mockResolvedValue({ id: 'meeting-2' });
-      await gateway.handleJoinRoom({ meetingId: 'meeting-2' }, socket);
-
-      // Disconnect
       const mockServer = gateway as unknown as { server: { to: jest.Mock } };
-      const serverEmit = jest.fn();
-      mockServer.server.to.mockReturnValue({ emit: serverEmit });
+      mockServer.server.to.mockReturnValue(mockServerToChain);
 
       gateway.handleDisconnect(socket);
 
-      // Should have broadcast participant-left for both rooms
-      expect(serverEmit).toHaveBeenCalledTimes(2);
-      expect(serverEmit).toHaveBeenCalledWith(
+      expect(mockSessionService.removeParticipant).toHaveBeenCalledTimes(2);
+      expect(mockServerToChain.emit).toHaveBeenCalledTimes(2);
+      expect(mockServerToChain.emit).toHaveBeenCalledWith(
         'participant-left',
-        expect.objectContaining({ meetingId: 'meeting-1' }),
+        expect.objectContaining({ meetingId: MEETING_UUID }),
       );
-      expect(serverEmit).toHaveBeenCalledWith(
+      expect(mockServerToChain.emit).toHaveBeenCalledWith(
         'participant-left',
-        expect.objectContaining({ meetingId: 'meeting-2' }),
+        expect.objectContaining({ meetingId: MEETING_UUID_2 }),
       );
     });
 
-    it('should clean up empty rooms after last participant leaves', async () => {
-      const socket = createMockSocket();
+    it('should not throw after a rate-limited socket disconnects', () => {
+      const socket = createMockSocket({ id: 'socket-rl' });
       socket.data.user = fakeUser as never;
-      meetingsRepository.findById.mockResolvedValue({ id: 'meeting-1' });
-      meetingsRepository.findMemberByMeetingAndUser.mockResolvedValue({ id: 'member-1' });
-      (socket.to as jest.Mock).mockReturnValue({ emit: jest.fn() });
-      await gateway.handleJoinRoom({ meetingId: 'meeting-1' }, socket);
+      mockSessionService.isParticipant.mockReturnValue(true);
 
-      // Verify room exists
-      const socket2 = createMockSocket({ id: 'socket-2' });
-      socket2.data.user = fakeUser2 as never;
-      meetingsRepository.findMemberByMeetingAndUser.mockResolvedValue({ id: 'member-2' });
-      await gateway.handleGetParticipants({ meetingId: 'meeting-1' }, socket2);
-      const firstCall = (socket2.emit as jest.Mock).mock.calls[0];
-      const participants = (firstCall[1] as { participants: ParticipantInfo[] }).participants;
-      expect(participants).toHaveLength(1);
-
-      // Disconnect last participant
       const mockServer = gateway as unknown as { server: { to: jest.Mock } };
-      mockServer.server.to.mockReturnValue({ emit: jest.fn() });
-      gateway.handleDisconnect(socket);
+      mockServer.server.to.mockReturnValue(mockServerToChain);
 
-      // Room should be empty
-      (socket2.emit as jest.Mock).mockClear();
-      await gateway.handleGetParticipants({ meetingId: 'meeting-1' }, socket2);
-      const secondCall = (socket2.emit as jest.Mock).mock.calls[0];
-      const remaining = (secondCall[1] as { participants: ParticipantInfo[] }).participants;
-      expect(remaining).toHaveLength(0);
+      gateway.handleOffer(
+        { meetingId: MEETING_UUID, targetSocketId: TARGET_SOCKET_ID, payload: {} },
+        socket,
+      );
+
+      expect(() => gateway.handleDisconnect(socket)).not.toThrow();
     });
   });
 });

--- a/src/signaling/signaling.gateway.ts
+++ b/src/signaling/signaling.gateway.ts
@@ -7,38 +7,26 @@ import {
   MessageBody,
   ConnectedSocket,
 } from '@nestjs/websockets';
-import { Logger, UnauthorizedException } from '@nestjs/common';
+import { Inject, Logger, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { Server, Socket } from 'socket.io';
 import { User } from '@prisma/client';
+import { plainToInstance } from 'class-transformer';
+import { validateSync, ValidationError } from 'class-validator';
 import { UsersRepository } from '../users/users.repository';
 import { MeetingsRepository } from '../meetings/meetings.repository';
 import { JwtPayload } from '../auth/interfaces/jwt-payload.interface';
+import { SIGNALING_SESSION_SERVICE } from './signaling-session.interface';
+import type { ISignalingSessionService, ParticipantInfo } from './signaling-session.interface';
+import { WatchMeetingDto } from './dto/watch-meeting.dto';
+import { JoinRoomDto } from './dto/join-room.dto';
+import { LeaveRoomDto } from './dto/leave-room.dto';
+import { RelayDto } from './dto/relay.dto';
 
-export interface ParticipantInfo {
-  socketId: string;
-  userId: string;
-  name: string;
-  joinedAt: number;
-}
+const RELAY_RATE_LIMIT = 30;
+const RELAY_RATE_WINDOW_MS = 10_000;
 
-interface WatchMeetingPayload {
-  meetingId: string;
-}
-
-interface JoinRoomPayload {
-  meetingId: string;
-}
-
-interface LeaveRoomPayload {
-  meetingId: string;
-}
-
-interface SignalingRelayPayload {
-  meetingId: string;
-  targetSocketId: string;
-  payload: unknown;
-}
+export type { ParticipantInfo };
 
 interface SignalingRelayServerPayload {
   fromSocketId: string;
@@ -56,12 +44,12 @@ interface ServerToClientEvents {
 }
 
 interface ClientToServerEvents {
-  'watch-meeting': (payload: WatchMeetingPayload) => void;
-  'join-room': (payload: JoinRoomPayload) => void;
-  'leave-room': (payload: LeaveRoomPayload) => void;
-  offer: (payload: SignalingRelayPayload) => void;
-  answer: (payload: SignalingRelayPayload) => void;
-  'ice-candidate': (payload: SignalingRelayPayload) => void;
+  'watch-meeting': (payload: WatchMeetingDto) => void;
+  'join-room': (payload: JoinRoomDto) => void;
+  'leave-room': (payload: LeaveRoomDto) => void;
+  offer: (payload: RelayDto) => void;
+  answer: (payload: RelayDto) => void;
+  'ice-candidate': (payload: RelayDto) => void;
 }
 
 interface SocketData {
@@ -75,6 +63,11 @@ type AuthenticatedSocket = Socket<
   SocketData
 >;
 
+interface RateBucket {
+  count: number;
+  windowStart: number;
+}
+
 @WebSocketGateway({
   cors: {
     origin: process.env.CLIENT_ORIGIN ?? 'http://localhost:5173',
@@ -87,16 +80,15 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
 
   private readonly logger = new Logger(SignalingGateway.name);
 
-  /** meetingId → (socketId → ParticipantInfo) */
-  private readonly rooms = new Map<string, Map<string, ParticipantInfo>>();
-
-  /** socketId → Set<meetingId> (reverse index for O(k) disconnect cleanup) */
-  private readonly socketRooms = new Map<string, Set<string>>();
+  /** Per-socket relay rate-limit tracking (I/O concern — kept in gateway) */
+  private readonly rateLimits = new Map<string, RateBucket>();
 
   constructor(
     private readonly jwtService: JwtService,
     private readonly usersRepository: UsersRepository,
     private readonly meetingsRepository: MeetingsRepository,
+    @Inject(SIGNALING_SESSION_SERVICE)
+    private readonly sessionService: ISignalingSessionService,
   ) {}
 
   async handleConnection(socket: AuthenticatedSocket): Promise<void> {
@@ -116,10 +108,14 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
 
       const { passwordHash: _pw, ...safeUser } = user;
       socket.data.user = safeUser;
-      this.logger.log(`Client connected: socketId=${socket.id} userId=${user.id}`);
+      this.logger.log(
+        `event=connect socketId=${socket.id} userId=${user.id} ts=${new Date().toISOString()}`,
+      );
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unauthorized';
-      this.logger.warn(`Connection rejected: socketId=${socket.id} reason=${message}`);
+      this.logger.warn(
+        `event=connect-rejected socketId=${socket.id} reason=${message} ts=${new Date().toISOString()}`,
+      );
       socket.emit('error', { code: 401, message });
       socket.disconnect(true);
     }
@@ -128,16 +124,19 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
   handleDisconnect(socket: AuthenticatedSocket): void {
     const userId: string | undefined = socket.data.user?.id;
     this.logger.log(
-      `Client disconnected: socketId=${socket.id} userId=${userId ?? 'unauthenticated'}`,
+      `event=disconnect socketId=${socket.id} userId=${userId ?? 'unauthenticated'} ts=${new Date().toISOString()}`,
     );
 
-    // Clean up presence for every room this socket was in
+    // Clean up rate-limit bucket
+    this.rateLimits.delete(socket.id);
+
+    // Clean up presence in all rooms this socket was in
     this.cleanupSocket(socket);
   }
 
   @SubscribeMessage('watch-meeting')
   async handleWatchMeeting(
-    @MessageBody() payload: WatchMeetingPayload,
+    @MessageBody() raw: unknown,
     @ConnectedSocket() socket: AuthenticatedSocket,
   ): Promise<void> {
     if (!socket.data.user) {
@@ -145,34 +144,40 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
       return;
     }
 
-    if (!payload?.meetingId || typeof payload.meetingId !== 'string') {
-      socket.emit('error', { code: 400, message: 'meetingId is required' });
-      return;
-    }
+    const dto = this.validateSocketPayload(WatchMeetingDto, raw, socket);
+    if (!dto) return;
 
-    const { meetingId } = payload;
+    const { meetingId } = dto;
 
-    // Validate meeting exists
     const meeting = await this.meetingsRepository.findById(meetingId);
     if (!meeting) {
       socket.emit('error', { code: 404, message: `Meeting ${meetingId} not found` });
       return;
     }
 
-    const watchRoom = `watch:${meetingId}`;
-    await socket.join(watchRoom);
-    this.logger.log(`Watcher joined lobby: meetingId=${meetingId} socketId=${socket.id}`);
+    const membership = await this.meetingsRepository.findMemberByMeetingAndUser(
+      meetingId,
+      socket.data.user.id,
+    );
+    if (!membership) {
+      socket.emit('error', { code: 403, message: 'Not a member of this meeting' });
+      return;
+    }
 
-    // Send the current participant list to the watcher
+    await socket.join(`watch:${meetingId}`);
+    this.logger.log(
+      `event=watch-meeting meetingId=${meetingId} socketId=${socket.id} userId=${socket.data.user.id} ts=${new Date().toISOString()}`,
+    );
+
     socket.emit('participants-list', {
       meetingId,
-      participants: this.getParticipants(meetingId),
+      participants: this.sessionService.getParticipants(meetingId),
     });
   }
 
   @SubscribeMessage('join-room')
   async handleJoinRoom(
-    @MessageBody() payload: JoinRoomPayload,
+    @MessageBody() raw: unknown,
     @ConnectedSocket() socket: AuthenticatedSocket,
   ): Promise<void> {
     const user = socket.data.user;
@@ -181,55 +186,48 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
       return;
     }
 
-    if (!payload?.meetingId || typeof payload.meetingId !== 'string') {
-      socket.emit('error', { code: 400, message: 'meetingId is required' });
-      return;
-    }
+    const dto = this.validateSocketPayload(JoinRoomDto, raw, socket);
+    if (!dto) return;
 
-    const { meetingId } = payload;
+    const { meetingId } = dto;
 
-    // Validate meeting exists
     const meeting = await this.meetingsRepository.findById(meetingId);
     if (!meeting) {
       socket.emit('error', { code: 404, message: `Meeting ${meetingId} not found` });
       return;
     }
 
-    // Validate user is a DB member of the meeting
     const membership = await this.meetingsRepository.findMemberByMeetingAndUser(meetingId, user.id);
     if (!membership) {
       socket.emit('error', { code: 403, message: 'Not a member of this meeting' });
       return;
     }
 
-    // No-op if already present in the room (prevents duplicate participant-joined events)
-    if (this.rooms.get(meetingId)?.has(socket.id)) return;
+    // No-op if already present — prevents duplicate participant-joined broadcasts
+    if (this.sessionService.isParticipant(meetingId, socket.id)) return;
 
-    // Join the video-call Socket.IO room and record presence
     await socket.join(meetingId);
-    const participant = this.addToRoom(meetingId, socket.id, user);
+    const participant = this.sessionService.addParticipant(meetingId, socket.id, user);
 
     this.logger.log(
-      `User joined room: meetingId=${meetingId} socketId=${socket.id} userId=${user.id}`,
+      `event=join-room meetingId=${meetingId} socketId=${socket.id} userId=${user.id} ts=${new Date().toISOString()}`,
     );
 
-    // Broadcast participant-joined to video-call participants and lobby watchers
-    // socket.to() excludes the sender; emit to the union of both rooms
+    // Broadcast to call room + lobby watchers; socket.to() excludes the sender
     socket.to(meetingId).to(`watch:${meetingId}`).emit('participant-joined', {
       meetingId,
       participant,
     });
 
-    // Send the current participant list to the joining socket
     socket.emit('participants-list', {
       meetingId,
-      participants: this.getParticipants(meetingId),
+      participants: this.sessionService.getParticipants(meetingId),
     });
   }
 
   @SubscribeMessage('leave-room')
   handleLeaveRoom(
-    @MessageBody() payload: LeaveRoomPayload,
+    @MessageBody() raw: unknown,
     @ConnectedSocket() socket: AuthenticatedSocket,
   ): void {
     const user = socket.data.user;
@@ -238,42 +236,37 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
       return;
     }
 
-    if (!payload?.meetingId || typeof payload.meetingId !== 'string') {
-      socket.emit('error', { code: 400, message: 'meetingId is required' });
-      return;
-    }
+    const dto = this.validateSocketPayload(LeaveRoomDto, raw, socket);
+    if (!dto) return;
 
-    const { meetingId } = payload;
-    this.removeFromRoomAndBroadcast(meetingId, socket);
+    this.logger.log(
+      `event=leave-room meetingId=${dto.meetingId} socketId=${socket.id} userId=${user.id} ts=${new Date().toISOString()}`,
+    );
+
+    this.removeFromRoomAndBroadcast(dto.meetingId, socket);
   }
 
   @SubscribeMessage('offer')
-  handleOffer(
-    @MessageBody() payload: SignalingRelayPayload,
-    @ConnectedSocket() socket: AuthenticatedSocket,
-  ): void {
-    this.handleSignalingRelay('offer', payload, socket);
+  handleOffer(@MessageBody() raw: unknown, @ConnectedSocket() socket: AuthenticatedSocket): void {
+    this.handleSignalingRelay('offer', raw, socket);
   }
 
   @SubscribeMessage('answer')
-  handleAnswer(
-    @MessageBody() payload: SignalingRelayPayload,
-    @ConnectedSocket() socket: AuthenticatedSocket,
-  ): void {
-    this.handleSignalingRelay('answer', payload, socket);
+  handleAnswer(@MessageBody() raw: unknown, @ConnectedSocket() socket: AuthenticatedSocket): void {
+    this.handleSignalingRelay('answer', raw, socket);
   }
 
   @SubscribeMessage('ice-candidate')
   handleIceCandidate(
-    @MessageBody() payload: SignalingRelayPayload,
+    @MessageBody() raw: unknown,
     @ConnectedSocket() socket: AuthenticatedSocket,
   ): void {
-    this.handleSignalingRelay('ice-candidate', payload, socket);
+    this.handleSignalingRelay('ice-candidate', raw, socket);
   }
 
   private handleSignalingRelay(
     event: 'offer' | 'answer' | 'ice-candidate',
-    payload: SignalingRelayPayload,
+    raw: unknown,
     socket: AuthenticatedSocket,
   ): void {
     if (!socket.data.user) {
@@ -281,119 +274,104 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
       return;
     }
 
-    if (
-      !payload?.meetingId ||
-      typeof payload.meetingId !== 'string' ||
-      !payload?.targetSocketId ||
-      typeof payload.targetSocketId !== 'string'
-    ) {
-      socket.emit('error', { code: 400, message: 'meetingId and targetSocketId are required' });
-      return;
-    }
+    const dto = this.validateSocketPayload(RelayDto, raw, socket);
+    if (!dto) return;
 
-    const { meetingId, targetSocketId } = payload;
+    if (!this.checkRateLimit(socket)) return;
 
-    if (!this.rooms.get(meetingId)?.has(socket.id)) {
+    const { meetingId, targetSocketId } = dto;
+
+    if (!this.sessionService.isParticipant(meetingId, socket.id)) {
       socket.emit('error', { code: 403, message: 'You are not in this room' });
       return;
     }
 
-    if (!this.rooms.get(meetingId)?.has(targetSocketId)) {
+    if (!this.sessionService.isParticipant(meetingId, targetSocketId)) {
       socket.emit('error', { code: 404, message: 'Target socket is not in this room' });
       return;
     }
 
     this.logger.log(
-      `WebRTC relay: event=${event} meetingId=${meetingId} from=${socket.id} to=${targetSocketId}`,
+      `event=${event} meetingId=${meetingId} socketId=${socket.id} userId=${socket.data.user.id} targetSocketId=${targetSocketId} ts=${new Date().toISOString()}`,
+    );
+
+    this.server.to(targetSocketId).emit(event, { fromSocketId: socket.id, payload: dto.payload });
+  }
+
+  private removeFromRoomAndBroadcast(meetingId: string, socket: AuthenticatedSocket): void {
+    const participant = this.sessionService.removeParticipant(meetingId, socket.id);
+    if (!participant) return;
+
+    void socket.leave(meetingId);
+    this.logger.log(
+      `event=left-room meetingId=${meetingId} socketId=${socket.id} userId=${participant.userId} ts=${new Date().toISOString()}`,
     );
 
     this.server
-      .to(targetSocketId)
-      .emit(event, { fromSocketId: socket.id, payload: payload.payload });
-  }
-
-  private addToRoom(
-    meetingId: string,
-    socketId: string,
-    user: Omit<User, 'passwordHash'>,
-  ): ParticipantInfo {
-    if (!this.rooms.has(meetingId)) {
-      this.rooms.set(meetingId, new Map());
-    }
-
-    const participant: ParticipantInfo = {
-      socketId,
-      userId: user.id,
-      name: user.name ?? 'Anonymous',
-      joinedAt: Date.now(),
-    };
-
-    this.rooms.get(meetingId)!.set(socketId, participant);
-
-    // Maintain the reverse index
-    if (!this.socketRooms.has(socketId)) {
-      this.socketRooms.set(socketId, new Set());
-    }
-    this.socketRooms.get(socketId)!.add(meetingId);
-
-    return participant;
-  }
-
-  private removeFromRoom(meetingId: string, socketId: string): ParticipantInfo | undefined {
-    const room = this.rooms.get(meetingId);
-    if (!room) return undefined;
-
-    const participant = room.get(socketId);
-    if (!participant) return undefined;
-
-    room.delete(socketId);
-
-    if (room.size === 0) {
-      this.rooms.delete(meetingId);
-    }
-
-    // Update the reverse index
-    const socketMeetings = this.socketRooms.get(socketId);
-    if (socketMeetings) {
-      socketMeetings.delete(meetingId);
-      if (socketMeetings.size === 0) {
-        this.socketRooms.delete(socketId);
-      }
-    }
-
-    return participant;
-  }
-
-  private getParticipants(meetingId: string): ParticipantInfo[] {
-    const room = this.rooms.get(meetingId);
-    return room ? Array.from(room.values()) : [];
+      .to(meetingId)
+      .to(`watch:${meetingId}`)
+      .emit('participant-left', { meetingId, participant });
   }
 
   private cleanupSocket(socket: AuthenticatedSocket): void {
-    const meetingIds = this.socketRooms.get(socket.id);
-    if (!meetingIds || meetingIds.size === 0) return;
+    const meetingIds = this.sessionService.getSocketRooms(socket.id);
+    if (meetingIds.size === 0) return;
 
-    // Snapshot before iterating since removeFromRoom mutates socketRooms during the loop
+    // Snapshot before iterating — removeParticipant mutates the underlying Set
     const snapshot = Array.from(meetingIds);
     for (const meetingId of snapshot) {
       this.removeFromRoomAndBroadcast(meetingId, socket);
     }
   }
 
-  private removeFromRoomAndBroadcast(meetingId: string, socket: AuthenticatedSocket): void {
-    const participant = this.removeFromRoom(meetingId, socket.id);
-    if (!participant) return;
+  /**
+   * Validates raw Socket.IO message data against a DTO class.
+   * Emits a `400` error to the socket on the first failure and returns `null`.
+   */
+  private validateSocketPayload<T extends object>(
+    cls: new () => T,
+    raw: unknown,
+    socket: AuthenticatedSocket,
+  ): T | null {
+    const instance = plainToInstance(cls, raw);
+    const errors: ValidationError[] = validateSync(instance as object, {
+      whitelist: true,
+      forbidNonWhitelisted: false,
+    });
+    if (errors.length > 0) {
+      const firstMessage = Object.values(errors[0].constraints ?? {})[0] ?? 'Invalid payload';
+      this.logger.warn(
+        `event=validation-failed socketId=${socket.id} constraint=${firstMessage} ts=${new Date().toISOString()}`,
+      );
+      socket.emit('error', { code: 400, message: firstMessage });
+      return null;
+    }
+    return instance;
+  }
 
-    void socket.leave(meetingId);
-    this.logger.log(
-      `User left room: meetingId=${meetingId} socketId=${socket.id} userId=${participant.userId}`,
-    );
+  /**
+   * Sliding-window rate limiter for relay events.
+   * Returns `true` if within the allowed limit; emits `429` and returns `false` otherwise.
+   */
+  private checkRateLimit(socket: AuthenticatedSocket): boolean {
+    const now = Date.now();
+    const bucket = this.rateLimits.get(socket.id);
 
-    // Notify video-call participants and lobby watchers
-    this.server
-      .to(meetingId)
-      .to(`watch:${meetingId}`)
-      .emit('participant-left', { meetingId, participant });
+    if (!bucket || now - bucket.windowStart >= RELAY_RATE_WINDOW_MS) {
+      this.rateLimits.set(socket.id, { count: 1, windowStart: now });
+      return true;
+    }
+
+    bucket.count += 1;
+    if (bucket.count > RELAY_RATE_LIMIT) {
+      socket.emit('error', {
+        code: 429,
+        message: 'Rate limit exceeded for signaling events',
+      });
+      return false;
+    }
+
+    return true;
   }
 
   private extractToken(socket: AuthenticatedSocket): string | undefined {
@@ -401,7 +379,7 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
     if (authToken) return authToken;
 
     const authHeader = socket.handshake.headers?.authorization;
-    if (authHeader?.startsWith('Bearer ')) {
+    if (typeof authHeader === 'string' && authHeader.startsWith('Bearer ')) {
       return authHeader.slice(7);
     }
 

--- a/src/signaling/signaling.gateway.ts
+++ b/src/signaling/signaling.gateway.ts
@@ -18,13 +18,13 @@ import { MeetingsRepository } from '../meetings/meetings.repository';
 import { JwtPayload } from '../auth/interfaces/jwt-payload.interface';
 import { SIGNALING_SESSION_SERVICE } from './signaling-session.interface';
 import type { ISignalingSessionService, ParticipantInfo } from './signaling-session.interface';
+import { SignalingRateLimiterService, SignalingEvent } from './signaling-rate-limiter.service';
 import { WatchMeetingDto } from './dto/watch-meeting.dto';
 import { JoinRoomDto } from './dto/join-room.dto';
 import { LeaveRoomDto } from './dto/leave-room.dto';
-import { RelayDto } from './dto/relay.dto';
-
-const RELAY_RATE_LIMIT = 30;
-const RELAY_RATE_WINDOW_MS = 10_000;
+import { OfferDto } from './dto/offer.dto';
+import { AnswerDto } from './dto/answer.dto';
+import { IceCandidateDto } from './dto/ice-candidate.dto';
 
 export type { ParticipantInfo };
 
@@ -47,9 +47,9 @@ interface ClientToServerEvents {
   'watch-meeting': (payload: WatchMeetingDto) => void;
   'join-room': (payload: JoinRoomDto) => void;
   'leave-room': (payload: LeaveRoomDto) => void;
-  offer: (payload: RelayDto) => void;
-  answer: (payload: RelayDto) => void;
-  'ice-candidate': (payload: RelayDto) => void;
+  offer: (payload: OfferDto) => void;
+  answer: (payload: AnswerDto) => void;
+  'ice-candidate': (payload: IceCandidateDto) => void;
 }
 
 interface SocketData {
@@ -63,11 +63,6 @@ type AuthenticatedSocket = Socket<
   SocketData
 >;
 
-interface RateBucket {
-  count: number;
-  windowStart: number;
-}
-
 @WebSocketGateway({
   cors: {
     origin: process.env.CLIENT_ORIGIN ?? 'http://localhost:5173',
@@ -80,15 +75,13 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
 
   private readonly logger = new Logger(SignalingGateway.name);
 
-  /** Per-socket relay rate-limit tracking (I/O concern — kept in gateway) */
-  private readonly rateLimits = new Map<string, RateBucket>();
-
   constructor(
     private readonly jwtService: JwtService,
     private readonly usersRepository: UsersRepository,
     private readonly meetingsRepository: MeetingsRepository,
     @Inject(SIGNALING_SESSION_SERVICE)
     private readonly sessionService: ISignalingSessionService,
+    private readonly rateLimiter: SignalingRateLimiterService,
   ) {}
 
   async handleConnection(socket: AuthenticatedSocket): Promise<void> {
@@ -127,10 +120,7 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
       `event=disconnect socketId=${socket.id} userId=${userId ?? 'unauthenticated'} ts=${new Date().toISOString()}`,
     );
 
-    // Clean up rate-limit bucket
-    this.rateLimits.delete(socket.id);
-
-    // Clean up presence in all rooms this socket was in
+    this.rateLimiter.clearSocket(socket.id);
     this.cleanupSocket(socket);
   }
 
@@ -207,13 +197,20 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
     if (this.sessionService.isParticipant(meetingId, socket.id)) return;
 
     await socket.join(meetingId);
-    const participant = this.sessionService.addParticipant(meetingId, socket.id, user);
+    const { participant, evictedSocketId } = this.sessionService.addParticipant(
+      meetingId,
+      socket.id,
+      user,
+    );
+
+    if (evictedSocketId) {
+      this.server.sockets.sockets.get(evictedSocketId)?.disconnect(true);
+    }
 
     this.logger.log(
       `event=join-room meetingId=${meetingId} socketId=${socket.id} userId=${user.id} ts=${new Date().toISOString()}`,
     );
 
-    // Broadcast to call room + lobby watchers; socket.to() excludes the sender
     socket.to(meetingId).to(`watch:${meetingId}`).emit('participant-joined', {
       meetingId,
       participant,
@@ -239,21 +236,23 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
     const dto = this.validateSocketPayload(LeaveRoomDto, raw, socket);
     if (!dto) return;
 
+    if (!this.sessionService.isParticipant(dto.meetingId, socket.id)) return;
+
     this.logger.log(
       `event=leave-room meetingId=${dto.meetingId} socketId=${socket.id} userId=${user.id} ts=${new Date().toISOString()}`,
     );
 
-    this.removeFromRoomAndBroadcast(dto.meetingId, socket);
+    this.removeFromRoomAndBroadcast(socket);
   }
 
   @SubscribeMessage('offer')
   handleOffer(@MessageBody() raw: unknown, @ConnectedSocket() socket: AuthenticatedSocket): void {
-    this.handleSignalingRelay('offer', raw, socket);
+    this.handleSignalingRelay('offer', OfferDto, raw, socket);
   }
 
   @SubscribeMessage('answer')
   handleAnswer(@MessageBody() raw: unknown, @ConnectedSocket() socket: AuthenticatedSocket): void {
-    this.handleSignalingRelay('answer', raw, socket);
+    this.handleSignalingRelay('answer', AnswerDto, raw, socket);
   }
 
   @SubscribeMessage('ice-candidate')
@@ -261,11 +260,12 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
     @MessageBody() raw: unknown,
     @ConnectedSocket() socket: AuthenticatedSocket,
   ): void {
-    this.handleSignalingRelay('ice-candidate', raw, socket);
+    this.handleSignalingRelay('ice-candidate', IceCandidateDto, raw, socket);
   }
 
   private handleSignalingRelay(
-    event: 'offer' | 'answer' | 'ice-candidate',
+    event: SignalingEvent,
+    dtoClass: new () => OfferDto | AnswerDto | IceCandidateDto,
     raw: unknown,
     socket: AuthenticatedSocket,
   ): void {
@@ -274,10 +274,13 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
       return;
     }
 
-    const dto = this.validateSocketPayload(RelayDto, raw, socket);
+    const dto = this.validateSocketPayload(dtoClass, raw, socket);
     if (!dto) return;
 
-    if (!this.checkRateLimit(socket)) return;
+    if (!this.rateLimiter.check(socket.id, event)) {
+      socket.emit('error', { code: 429, message: 'Too many signaling events' });
+      return;
+    }
 
     const { meetingId, targetSocketId } = dto;
 
@@ -298,10 +301,11 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
     this.server.to(targetSocketId).emit(event, { fromSocketId: socket.id, payload: dto.payload });
   }
 
-  private removeFromRoomAndBroadcast(meetingId: string, socket: AuthenticatedSocket): void {
-    const participant = this.sessionService.removeParticipant(meetingId, socket.id);
-    if (!participant) return;
+  private removeFromRoomAndBroadcast(socket: AuthenticatedSocket): void {
+    const result = this.sessionService.removeParticipant(socket.id);
+    if (!result) return;
 
+    const { meetingId, participant } = result;
     void socket.leave(meetingId);
     this.logger.log(
       `event=left-room meetingId=${meetingId} socketId=${socket.id} userId=${participant.userId} ts=${new Date().toISOString()}`,
@@ -314,20 +318,9 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
   }
 
   private cleanupSocket(socket: AuthenticatedSocket): void {
-    const meetingIds = this.sessionService.getSocketRooms(socket.id);
-    if (meetingIds.size === 0) return;
-
-    // Snapshot before iterating — removeParticipant mutates the underlying Set
-    const snapshot = Array.from(meetingIds);
-    for (const meetingId of snapshot) {
-      this.removeFromRoomAndBroadcast(meetingId, socket);
-    }
+    this.removeFromRoomAndBroadcast(socket);
   }
 
-  /**
-   * Validates raw Socket.IO message data against a DTO class.
-   * Emits a `400` error to the socket on the first failure and returns `null`.
-   */
   private validateSocketPayload<T extends object>(
     cls: new () => T,
     raw: unknown,
@@ -347,31 +340,6 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
       return null;
     }
     return instance;
-  }
-
-  /**
-   * Sliding-window rate limiter for relay events.
-   * Returns `true` if within the allowed limit; emits `429` and returns `false` otherwise.
-   */
-  private checkRateLimit(socket: AuthenticatedSocket): boolean {
-    const now = Date.now();
-    const bucket = this.rateLimits.get(socket.id);
-
-    if (!bucket || now - bucket.windowStart >= RELAY_RATE_WINDOW_MS) {
-      this.rateLimits.set(socket.id, { count: 1, windowStart: now });
-      return true;
-    }
-
-    bucket.count += 1;
-    if (bucket.count > RELAY_RATE_LIMIT) {
-      socket.emit('error', {
-        code: 429,
-        message: 'Rate limit exceeded for signaling events',
-      });
-      return false;
-    }
-
-    return true;
   }
 
   private extractToken(socket: AuthenticatedSocket): string | undefined {

--- a/src/signaling/signaling.module.ts
+++ b/src/signaling/signaling.module.ts
@@ -1,11 +1,19 @@
 import { Module } from '@nestjs/common';
 import { SignalingGateway } from './signaling.gateway';
+import { SignalingSessionService } from './signaling-session.service';
+import { SIGNALING_SESSION_SERVICE } from './signaling-session.interface';
 import { AuthModule } from '../auth/auth.module';
 import { UsersModule } from '../users/users.module';
 import { MeetingsModule } from '../meetings/meetings.module';
 
 @Module({
   imports: [AuthModule, UsersModule, MeetingsModule],
-  providers: [SignalingGateway],
+  providers: [
+    SignalingGateway,
+    {
+      provide: SIGNALING_SESSION_SERVICE,
+      useClass: SignalingSessionService,
+    },
+  ],
 })
 export class SignalingModule {}

--- a/src/signaling/signaling.module.ts
+++ b/src/signaling/signaling.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { SignalingGateway } from './signaling.gateway';
 import { SignalingSessionService } from './signaling-session.service';
+import { SignalingRateLimiterService } from './signaling-rate-limiter.service';
 import { SIGNALING_SESSION_SERVICE } from './signaling-session.interface';
 import { AuthModule } from '../auth/auth.module';
 import { UsersModule } from '../users/users.module';
@@ -10,6 +11,7 @@ import { MeetingsModule } from '../meetings/meetings.module';
   imports: [AuthModule, UsersModule, MeetingsModule],
   providers: [
     SignalingGateway,
+    SignalingRateLimiterService,
     {
       provide: SIGNALING_SESSION_SERVICE,
       useClass: SignalingSessionService,


### PR DESCRIPTION
## References
- #17

## Description
- Extract in-memory session state from SignalingGateway into injectable SignalingSessionService
- Define ISignalingSessionService with SIGNALING_SESSION_SERVICE DI token for future Redis swap
- Add class-validator DTOs (WatchMeetingDto, JoinRoomDto, LeaveRoomDto, RelayDto) for Socket.IO payload validation
- Add per-socket sliding-window rate limiter (30 events/10 s) for offer/answer/ice-candidate
- Add membership authorization check in handleWatchMeeting (403 for non-members)
- Improve structured logging with meetingId, socketId, userId, timestamp on all lifecycle events

## Test plan
- [x] 49 unit tests pass (pnpm test)
- [x] Malformed relay payload returns code 400, no relay occurs
- [x] Socket exceeding rate limit receives code 429
- [x] Non-member watch-meeting request receives code 403
- [x] Last participant leaving clears meeting from in-memory Maps
- [x] Disconnect broadcasts participant-left to both call room and watch lobby
