### PR TITLE
refactor(signaling): separate pre-join and in-call flows

### DIFF
--- a/.github/plans/WM-6.md
+++ b/.github/plans/WM-6.md
@@ -1,0 +1,197 @@
+# WM-6: Refactor backend to stateless participant model
+
+---
+
+## 1. Feature Summary
+
+Remove the `meetingMember` database table and all related code so that any authenticated user with a valid meeting link can join a meeting via Socket.IO `join-room` without requiring a pre-created membership record. The in-memory `SignalingSessionService` (introduced in WM-5) becomes the sole source of truth for who is currently in a call. REST and WebSocket APIs are updated accordingly, and `docs/MEETING_API.md` and `docs/signaling-events.md` are revised to reflect the new behaviour.
+
+---
+
+## 2. Problem Statement
+
+The current flow forces server-side state across two layers: the `meetingMember` Postgres table (persistent) and the in-memory `SignalingSessionService` (ephemeral). Every time a user wants to join a meeting, the gateway checks `findMemberByMeetingAndUser`, which means they must have a `meetingMember` row created either during `POST /meetings` or via `POST /meetings/:id/join`. This causes:
+
+- Unnecessary coupling between the REST and WebSocket layers.
+- A stateful join prerequisite that does not reflect real-time presence — a user can have a DB row but not be in the call, and vice versa.
+- Two code paths to maintain for participant tracking: the DB rows and the Maps.
+- Extra latency on every `join-room` and `watch-meeting` event due to the DB lookup.
+
+Removing `meetingMember` simplifies the model: a meeting exists in the DB; who is currently in it is tracked entirely in memory by `SignalingSessionService`.
+
+---
+
+## 3. Technical Design
+
+### Affected modules
+
+| Path                                       | Change                                                                                                                                                                                                            |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `prisma/schema.prisma`                     | Remove `MeetingMember` model, `MeetingRole` enum, `members` relation on `Meeting`, and `meetingMembers` relation on `User`                                                                                        |
+| `prisma/migrations/`                       | New migration to `DROP TABLE meeting_members; DROP TYPE "MeetingRole"`                                                                                                                                            |
+| `src/meetings/meetings.repository.ts`      | Remove `createMembershipWithinTransaction` and `findMemberByMeetingAndUser`                                                                                                                                       |
+| `src/meetings/meetings.service.ts`         | Remove `joinMeeting`; simplify `createMeeting` (no transaction needed); simplify `getMeetingDetails` (no `members` include)                                                                                       |
+| `src/meetings/meetings.controller.ts`      | Remove `POST /meetings/:id/join` endpoint                                                                                                                                                                         |
+| `src/meetings/dto/meeting-response.dto.ts` | Remove `members` field                                                                                                                                                                                            |
+| `src/meetings/dto/meeting-member.dto.ts`   | Delete file                                                                                                                                                                                                       |
+| `src/meetings/dto/join-meeting.dto.ts`     | Delete file (no longer needed)                                                                                                                                                                                    |
+| `src/signaling/signaling.gateway.ts`       | Remove `findMemberByMeetingAndUser` checks from `handleJoinRoom` and `handleWatchMeeting`                                                                                                                         |
+| `docs/MEETING_API.md`                      | Remove `POST /meetings/:id/join` documentation; remove `members` from response examples; remove schema docs for `MeetingMember` and `MeetingRole`; add note that participants are tracked in-memory via Socket.IO |
+| `docs/signaling-events.md`                 | Remove the note that `join-room` requires prior membership; clarify any authenticated user with a valid `meetingId` may join                                                                                      |
+
+### Services to modify or create
+
+#### `MeetingsRepository` (modify)
+
+- Remove `createMembershipWithinTransaction(tx, meetingId, userId, role)`
+- Remove `findMemberByMeetingAndUser(meetingId, userId)`
+- `findById` signature unchanged; remove optional `include` param or keep as-is for future use (no callers will pass `members` include after this change)
+
+#### `MeetingsService` (modify)
+
+- `createMeeting`: remove the `$transaction` wrapper; replace with a single `tx.meeting.create` call (no membership row to create). Return the flat `MeetingResponseDto` without `members`.
+- Remove `joinMeeting` method entirely.
+- `getMeetingDetails`: replace the `findById(id, { members: ... })` call with `findById(id)` (no include). Return the flat `MeetingResponseDto` without `members`.
+
+#### `SignalingGateway` (modify)
+
+- `handleJoinRoom`: remove the `findMemberByMeetingAndUser` check and the 403 response. Keep the `findById` existence check (404). After verifying the meeting exists, proceed directly to `isParticipant` guard → `addParticipant`.
+- `handleWatchMeeting`: remove the `findMemberByMeetingAndUser` check and the 403 response. Keep the `findById` existence check (404). Proceed directly to `socket.join(`watch:${meetingId}`)`.
+
+### Database changes
+
+1. Remove from `prisma/schema.prisma`:
+   - The `MeetingMember` model
+   - The `MeetingRole` enum
+   - The `members MeetingMember[]` relation on `Meeting`
+   - The `meetingMembers MeetingMember[]` relation on `User`
+
+2. Create a new migration:
+   ```sql
+   DROP TABLE "meeting_members";
+   -- MeetingRole enum removal is handled automatically by Prisma
+   ```
+   Use `prisma migrate dev --name remove_meeting_member` for development, then `prisma migrate deploy` in CI/production.
+
+### API endpoints
+
+| Method                        | Path             | Change                                                        |
+| ----------------------------- | ---------------- | ------------------------------------------------------------- |
+| `POST /api/meetings`          | Create meeting   | Response no longer includes `members`; no transaction         |
+| `GET /api/meetings/:id`       | Get meeting      | Response no longer includes `members`                         |
+| `POST /api/meetings/:id/join` | ~~Join meeting~~ | **Removed** — joining happens via `join-room` Socket.IO event |
+
+#### Updated `MeetingResponseDto`
+
+```
+{
+  id: string (UUID)
+  title: string
+  hostId: string (UUID)
+  createdAt: ISO 8601 timestamp
+  updatedAt: ISO 8601 timestamp
+}
+```
+
+### Validation rules
+
+- No changes to existing DTO validation.
+- `MeetingMemberDto` and `JoinMeetingDto` files are deleted; no references should remain after the refactor.
+- `MeetingRole` import from `@prisma/client` is removed wherever referenced (service, repository).
+
+---
+
+## 4. Edge Cases
+
+| Scenario                                                            | Handling                                                                                                                                                                       |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `GET /meetings/:id` called for a meeting that does not exist        | `NotFoundException` — unchanged behaviour                                                                                                                                      |
+| `join-room` emitted for a non-existent `meetingId`                  | Gateway returns `{ code: 404, message: 'Meeting <id> not found' }` — unchanged behaviour                                                                                       |
+| `watch-meeting` emitted for a non-existent `meetingId`              | Same 404 path — unchanged                                                                                                                                                      |
+| User joins the same meeting from two tabs simultaneously            | `addParticipant` evicts the old socket (duplicate userId eviction implemented in WM-5)                                                                                         |
+| Socket reconnects before the server processes the disconnect        | `handleDisconnect` calls `removeParticipant(oldSocketId)` first; new `handleJoinRoom` calls `addParticipant` which evicts the old entry if the same userId is still registered |
+| Migration run against a database with existing `meetingMember` rows | All rows are deleted when the table is dropped; confirm this is acceptable before running in production (stated in issue: safe to delete)                                      |
+| `MeetingRole` enum referenced in other code                         | Search confirms it is only used in `meetings.service.ts`, `meetings.repository.ts`, and the DTO; all removed in this PR                                                        |
+| Two users emitting `join-room` at the same time                     | Node.js is single-threaded; in-memory Map mutations are synchronous — no race condition                                                                                        |
+| `findById` is still used in the gateway; `include` param removal    | `findById` still accepts an optional `include` for future extensibility; existing gateway callers pass no `include`, so behaviour is unchanged                                 |
+
+---
+
+## 5. Implementation Plan
+
+1. **Audit `meetingMember` references** — Search the entire codebase for `meetingMember`, `MeetingMember`, `MeetingRole`, `joinMeeting`, `createMembershipWithinTransaction`, and `findMemberByMeetingAndUser` to produce a complete list of files to change before touching anything.
+
+2. **Update Prisma schema** — Remove the `MeetingMember` model, `MeetingRole` enum, and related relations from `schema.prisma`. Run `prisma migrate dev --name remove_meeting_member` to generate and apply the migration locally.
+
+3. **Simplify `MeetingsRepository`** — Delete the two membership methods. Remove the `MeetingRole` import. Keep `create` and `findById` as-is.
+
+4. **Simplify `MeetingsService`** — Replace `createMeeting`'s `$transaction` with a direct `prisma.meeting.create` call. Remove `joinMeeting`. Simplify `getMeetingDetails` to not include the `members` relation. Remove the `MeetingMemberDto` import and usage.
+
+5. **Remove `POST /meetings/:id/join` from the controller** — Delete the `joinMeeting` handler and its imports.
+
+6. **Delete obsolete DTO files** — Delete `meeting-member.dto.ts` and `join-meeting.dto.ts`. Update `meeting-response.dto.ts` to remove the `members` field and its import.
+
+7. **Remove membership checks from `SignalingGateway`** — In `handleJoinRoom` and `handleWatchMeeting`, remove the `findMemberByMeetingAndUser` call and the 403 guard. The `meetingsRepository` is still injected for the `findById` existence check.
+
+8. **Update `docs/MEETING_API.md`** — Remove the `POST /meetings/:id/join` section, update the `MeetingResponseDto` schema (no `members`), remove `MeetingMember` and `MeetingRole` schema docs, remove the `join-meeting.dto.ts` from the architecture tree, and add a note that live participants are tracked via `SignalingSessionService` over Socket.IO.
+
+9. **Update `docs/signaling-events.md`** — Update the `join-room` section to state that any authenticated user with a valid `meetingId` may join (no prior membership required). Remove any text that implies a membership check occurs.
+
+10. **Update tests** — Update `signaling.gateway.spec.ts` to remove the `findMemberByMeetingAndUser` mock from `handleJoinRoom` and `handleWatchMeeting` test cases. Update or delete any unit tests in `meetings.service.spec.ts` covering `joinMeeting` and the membership logic. Ensure `pnpm test` passes with 64+ tests.
+
+11. **Run build and tests** — `pnpm build` must pass with zero TS errors. `pnpm test` must pass all tests.
+
+---
+
+## 6. Implementation Order
+
+1. Audit all `meetingMember` / `MeetingRole` references across the codebase
+2. Update `prisma/schema.prisma` — remove `MeetingMember` model, `MeetingRole` enum, relations
+3. Generate and apply migration: `prisma migrate dev --name remove_meeting_member`
+4. Simplify `MeetingsRepository` — remove `createMembershipWithinTransaction` and `findMemberByMeetingAndUser`
+5. Simplify `MeetingsService` — remove `joinMeeting`, flatten `createMeeting`, simplify `getMeetingDetails`
+6. Remove `POST /meetings/:id/join` from `MeetingsController`
+7. Delete `src/meetings/dto/meeting-member.dto.ts` and `src/meetings/dto/join-meeting.dto.ts`
+8. Update `src/meetings/dto/meeting-response.dto.ts` — remove `members` field
+9. Remove `findMemberByMeetingAndUser` checks from `SignalingGateway.handleJoinRoom` and `handleWatchMeeting`
+10. Update `docs/MEETING_API.md`
+11. Update `docs/signaling-events.md`
+12. Update `signaling.gateway.spec.ts` (remove membership mock setup from join-room and watch-meeting tests)
+13. Update/delete any service-layer tests for `joinMeeting`
+14. Run `pnpm build` — verify zero TypeScript errors
+15. Run `pnpm test` — verify all tests pass
+
+---
+
+## 7. Task Breakdown
+
+- [ ] Run `grep -r "meetingMember\|MeetingMember\|MeetingRole\|joinMeeting\|createMembershipWithinTransaction\|findMemberByMeetingAndUser" src/ prisma/ docs/ --include="*.ts" --include="*.md" -l` to list all affected files
+- [ ] Remove `MeetingMember` model from `prisma/schema.prisma`
+- [ ] Remove `MeetingRole` enum from `prisma/schema.prisma`
+- [ ] Remove `members MeetingMember[]` relation from `Meeting` model in `prisma/schema.prisma`
+- [ ] Remove `meetingMembers MeetingMember[]` relation from `User` model in `prisma/schema.prisma`
+- [ ] Run `prisma migrate dev --name remove_meeting_member` and verify migration SQL
+- [ ] Delete `createMembershipWithinTransaction` from `MeetingsRepository`
+- [ ] Delete `findMemberByMeetingAndUser` from `MeetingsRepository`
+- [ ] Remove `MeetingRole` import from `MeetingsRepository`
+- [ ] Replace `createMeeting`'s `$transaction` with a direct `prisma.meeting.create` in `MeetingsService`
+- [ ] Delete `joinMeeting` method from `MeetingsService`
+- [ ] Replace `getMeetingDetails`'s `findById(id, { members: ... })` with `findById(id)` in `MeetingsService`
+- [ ] Remove `MeetingMemberDto` import and usage from `MeetingsService`
+- [ ] Remove `MeetingRole` import from `MeetingsService`
+- [ ] Delete `POST /meetings/:id/join` handler from `MeetingsController`
+- [ ] Delete `src/meetings/dto/meeting-member.dto.ts`
+- [ ] Delete `src/meetings/dto/join-meeting.dto.ts`
+- [ ] Remove `members?: MeetingMemberDto[]` field and import from `MeetingResponseDto`
+- [ ] Remove `findMemberByMeetingAndUser` call and 403 guard from `SignalingGateway.handleJoinRoom`
+- [ ] Remove `findMemberByMeetingAndUser` call and 403 guard from `SignalingGateway.handleWatchMeeting`
+- [ ] Update `docs/MEETING_API.md`: remove `POST /meetings/:id/join` section
+- [ ] Update `docs/MEETING_API.md`: remove `MeetingMember` and `MeetingRole` schema docs
+- [ ] Update `docs/MEETING_API.md`: update `MeetingResponseDto` examples to exclude `members`
+- [ ] Update `docs/MEETING_API.md`: remove `join-meeting.dto.ts` and `meeting-member.dto.ts` from architecture tree
+- [ ] Update `docs/MEETING_API.md`: add note that live participants are tracked in-memory via Socket.IO `SignalingSessionService`
+- [ ] Update `docs/signaling-events.md`: update `join-room` description — no membership check, any authenticated user may join
+- [ ] Update `signaling.gateway.spec.ts`: remove `findMemberByMeetingAndUser` mock setup and 403 assertions from `handleJoinRoom` and `handleWatchMeeting` test suites
+- [ ] Delete or update `meetings.service.spec.ts` tests covering `joinMeeting` and membership creation
+- [ ] Run `pnpm build` — confirm zero TypeScript errors
+- [ ] Run `pnpm test` — confirm 64+ tests pass

--- a/docs/MEETING_API.md
+++ b/docs/MEETING_API.md
@@ -4,15 +4,29 @@ All routes are prefixed with `/api`. All endpoints require a valid JWT Bearer to
 
 ---
 
+## Client Flow (Google Meet–style)
+
+The meeting experience follows a **pre-join / in-call** separation:
+
+| Phase                    | Client Action                                                             | Server Involvement                                                           |
+| ------------------------ | ------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| **1. Open meeting page** | `GET /meetings/:id`                                                       | Returns meeting metadata (title, hostId). User is **not** yet a participant. |
+| **2. Pre-join lobby**    | Render camera/mic preview. Optionally emit `watch-meeting` via WebSocket. | Sends current `participants-list` to the watcher. No in-call state created.  |
+| **3. Join call**         | Emit `join-room` via WebSocket.                                           | Adds user to in-memory participant store. Broadcasts `participant-joined`.   |
+| **4. In-call**           | WebRTC signaling (`offer`, `answer`, `ice-candidate`).                    | Relays signaling between peers.                                              |
+| **5. Leave**             | Emit `leave-room` or close the tab.                                       | Removes participant, broadcasts `participant-left`.                          |
+
+> **Presence is ephemeral.** It exists only after `join-room` and is cleared on `leave-room` or disconnect. The REST API never returns live participant data — use the `watch-meeting` WebSocket event for real-time presence.
+
+---
+
 ## Architecture
 
 ```
 meetings/
 ├── dto/                          # Data Transfer Objects
 │   ├── create-meeting.dto.ts     # Input: Create meeting
-│   ├── join-meeting.dto.ts       # Input: Join meeting
-│   ├── meeting-response.dto.ts   # Output: Meeting details
-│   └── meeting-member.dto.ts     # Output: Member info
+│   └── meeting-response.dto.ts   # Output: Meeting details
 ├── meetings.controller.ts        # HTTP routes
 ├── meetings.service.ts           # Business logic
 ├── meetings.repository.ts        # Data access layer
@@ -31,38 +45,14 @@ model Meeting {
   host      User     @relation("MeetingHost", fields: [hostId], references: [id], onDelete: Cascade)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
-  members   MeetingMember[]
 
   @@index([hostId])
 }
 ```
 
-### MeetingMember Model
+> **Note:** There is no persistent membership table. Participants are tracked in-memory via [SignalingSessionService](./signaling-events.md) over Socket.IO. Anyone with a valid JWT and meeting ID can join via the `join-room` WebSocket event.
 
-```prisma
-model MeetingMember {
-  id        String      @id @default(uuid())
-  meetingId String
-  meeting   Meeting     @relation(fields: [meetingId], references: [id], onDelete: Cascade)
-  userId    String
-  user      User        @relation(fields: [userId], references: [id], onDelete: Cascade)
-  role      MeetingRole  # HOST or PARTICIPANT
-  joinedAt  DateTime    @default(now())
-
-  @@unique([meetingId, userId], name: "unique_meeting_membership")
-  @@index([meetingId])
-  @@index([userId])
-}
-```
-
-### MeetingRole Enum
-
-```prisma
-enum MeetingRole {
-  HOST
-  PARTICIPANT
-}
-```
+---
 
 ## API Endpoints
 
@@ -70,7 +60,7 @@ enum MeetingRole {
 
 **POST /api/meetings**
 
-Creates a new meeting room and automatically adds the creator as HOST.
+Creates a new meeting room. The authenticated user becomes the host (`hostId`).
 
 **Authentication Required:** Yes (JWT Bearer token)
 
@@ -103,95 +93,13 @@ curl -X POST http://localhost:3000/api/meetings \
   -d '{"title": "Team Sync"}'
 ```
 
-**Transaction Behavior:**
-
-- Meeting creation and host membership are atomic (both succeed or both fail)
-- Host automatically gets `MeetingRole.HOST` role
-- If transaction fails, entire operation is rolled back
-
 ---
 
-### 2. Join Meeting
-
-**POST /api/meetings/:id/join**
-
-Adds the authenticated user to an existing meeting as PARTICIPANT.
-
-**Authentication Required:** Yes (JWT Bearer token)
-
-**Path Parameters:**
-
-- `id` (string, UUID): Meeting ID
-
-**Response (200 OK):**
-
-```json
-{
-  "id": "550e8400-e29b-41d4-a716-446655440000",
-  "title": "Weekly Standup",
-  "hostId": "123e4567-e89b-12d3-a456-426614174000",
-  "createdAt": "2024-02-24T10:00:00.000Z",
-  "updatedAt": "2024-02-24T10:00:00.000Z",
-  "members": [
-    {
-      "id": "mem-001",
-      "userId": "123e4567-e89b-12d3-a456-426614174000",
-      "userName": "John Doe",
-      "role": "HOST",
-      "joinedAt": "2024-02-24T10:00:00.000Z"
-    },
-    {
-      "id": "mem-002",
-      "userId": "789e4567-e89b-12d3-a456-426614174999",
-      "userName": "Jane Smith",
-      "role": "PARTICIPANT",
-      "joinedAt": "2024-02-24T10:05:00.000Z"
-    }
-  ]
-}
-```
-
-**Error Responses:**
-
-**404 Not Found:**
-
-```json
-{
-  "statusCode": 404,
-  "message": "Meeting with ID 550e8400-e29b-41d4-a716-446655440000 not found",
-  "error": "Not Found"
-}
-```
-
-**409 Conflict (Already a member):**
-
-```json
-{
-  "statusCode": 409,
-  "message": "You are already a member of this meeting",
-  "error": "Conflict"
-}
-```
-
-**Example (cURL):**
-
-```bash
-curl -X POST http://localhost:3000/api/meetings/550e8400-e29b-41d4-a716-446655440000/join \
-  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
-```
-
-**Duplicate Prevention:**
-
-- Unique constraint on `(meetingId, userId)` prevents duplicate memberships
-- Returns 409 Conflict if user is already a member
-
----
-
-### 3. Get Meeting Details
+### 2. Get Meeting Details
 
 **GET /api/meetings/:id**
 
-Retrieves meeting details including all members ordered by join time.
+Retrieves meeting metadata. Does **not** include live participant data — use the `watch-meeting` WebSocket event for real-time presence.
 
 **Authentication Required:** Yes (JWT Bearer token)
 
@@ -207,23 +115,7 @@ Retrieves meeting details including all members ordered by join time.
   "title": "Weekly Standup",
   "hostId": "123e4567-e89b-12d3-a456-426614174000",
   "createdAt": "2024-02-24T10:00:00.000Z",
-  "updatedAt": "2024-02-24T10:00:00.000Z",
-  "members": [
-    {
-      "id": "mem-001",
-      "userId": "123e4567-e89b-12d3-a456-426614174000",
-      "userName": "John Doe",
-      "role": "HOST",
-      "joinedAt": "2024-02-24T10:00:00.000Z"
-    },
-    {
-      "id": "mem-002",
-      "userId": "789e4567-e89b-12d3-a456-426614174999",
-      "userName": "Jane Smith",
-      "role": "PARTICIPANT",
-      "joinedAt": "2024-02-24T10:05:00.000Z"
-    }
-  ]
+  "updatedAt": "2024-02-24T10:00:00.000Z"
 }
 ```
 
@@ -244,10 +136,32 @@ curl -X GET http://localhost:3000/api/meetings/550e8400-e29b-41d4-a716-446655440
   -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
 ```
 
-**Optimization:**
+---
 
-- Single query with `include` for members and user names
-- Members ordered by `joinedAt` ASC (host appears first)
+## Response DTO
+
+### MeetingResponseDto
+
+| Field       | Type   | Description                                    |
+| ----------- | ------ | ---------------------------------------------- |
+| `id`        | string | UUID of the meeting                            |
+| `title`     | string | Meeting title (defaults to "Untitled Meeting") |
+| `hostId`    | string | UUID of the user who created the meeting       |
+| `createdAt` | string | ISO 8601 timestamp                             |
+| `updatedAt` | string | ISO 8601 timestamp                             |
+
+---
+
+## Participant Tracking
+
+Live participants are **not** stored in the database. They are tracked in-memory by `SignalingSessionService` via Socket.IO events:
+
+- **`join-room`** — The **only** event that makes a user an active participant. The gateway delegates to `canJoinMeeting()` — the single extension point for future join-gating (e.g., request-join / host-approval). Currently any authenticated user with a valid meeting ID may join. The server computes `isHost = user.id === meeting.hostId` and stores `{ userId, socketId, isHost }`.
+- **`participant-joined`** — Broadcast with `{ meetingId, participant: { userId, socketId, isHost } }`.
+- **`participant-left`** — Broadcast with `{ meetingId, participant: { userId, socketId, isHost } }`.
+- **`watch-meeting`** — Optional lobby observer: join the `watch:{meetingId}` room to receive the current `participants-list` and live updates without entering the call.
+
+See [signaling-events.md](./signaling-events.md) for full WebSocket documentation.
 
 ---
 
@@ -261,80 +175,32 @@ Authorization: Bearer <access_token>
 
 The user ID is extracted from the JWT payload using the `@CurrentUser('id')` decorator.
 
-## Role-Based Access Control
-
-### Current Roles
-
-- **HOST**: Meeting creator, full control
-- **PARTICIPANT**: Regular member
-
-### Future Extensions
-
-The `MeetingRole` enum can be extended for additional roles:
-
-```typescript
-enum MeetingRole {
-  HOST
-  CO_HOST      // Future: Elevated permissions
-  PARTICIPANT
-  OBSERVER     // Future: View-only access
-}
-```
+---
 
 ## Data Validation
 
 ### CreateMeetingDto
 
-```typescript
-{
-  title?: string;  // Optional, max 200 characters
-}
-```
+| Field   | Type   | Required | Rules              |
+| ------- | ------ | -------- | ------------------ |
+| `title` | string | No       | Max 200 characters |
 
-**Validation Rules:**
+If omitted, defaults to "Untitled Meeting".
 
-- `title`: Optional, string, max 200 characters
-- If omitted, defaults to "Untitled Meeting"
-
-### JoinMeetingDto
-
-The meeting ID is taken from the URL path parameter and validated as UUID.
+---
 
 ## Error Handling
 
 | Status Code               | Scenario                                  |
 | ------------------------- | ----------------------------------------- |
 | 201 Created               | Meeting created successfully              |
-| 200 OK                    | Join successful or details retrieved      |
+| 200 OK                    | Details retrieved                         |
 | 400 Bad Request           | Invalid input (e.g., non-UUID meeting ID) |
 | 401 Unauthorized          | Missing or invalid access token           |
 | 404 Not Found             | Meeting doesn't exist                     |
-| 409 Conflict              | User already member of meeting            |
 | 500 Internal Server Error | Database or server error                  |
 
-## Database Indexes
-
-Performance-optimized with strategic indexes:
-
-```prisma
-// Meeting indexes
-@@index([hostId])  // Fast lookup of user's hosted meetings
-
-// MeetingMember indexes
-@@unique([meetingId, userId])  // Prevent duplicate membership
-@@index([meetingId])           // Fast member lookup by meeting
-@@index([userId])              // Fast meeting lookup by user
-```
-
-## CASCADE Delete Behavior
-
-```
-User deleted → All hosted meetings deleted → All members removed
-User deleted → All memberships removed
-Meeting deleted → All members removed
-```
-
-This prevents orphaned records and ensures data integrity.
+---
 
 ## Repository Pattern
 
@@ -342,194 +208,16 @@ This prevents orphaned records and ensures data integrity.
 
 ```typescript
 class MeetingsRepository {
-  create(); // Create meeting
-  findById(id, include?); // Get meeting with optional relations
-  createMembershipWithinTransaction(); // Add member atomically
-  findMemberByMeetingAndUser(); // Check existing membership
+  create(data); // Create meeting
+  findById(id); // Get meeting by ID
 }
 ```
 
-**Benefits:**
-
-- Separation of concerns (data access vs business logic)
-- Testability (easy to mock repository)
-- Transaction support for atomic operations
-
-## Design Decisions
-
-### 1. **Transaction for Meeting Creation**
-
-Creating a meeting and adding the host as a member must be atomic. We use Prisma transactions:
-
-```typescript
-await this.prisma.$transaction(async (tx) => {
-  const meeting = await tx.meeting.create({ ... });
-  await tx.meetingMember.create({ ... });
-  return meeting;
-});
-```
-
-**Why:** Prevents meetings without hosts or failed partial operations.
-
-### 2. **Unique Constraint on (meetingId, userId)**
-
-Prevents duplicate memberships at the database level:
-
-```prisma
-@@unique([meetingId, userId], name: "unique_meeting_membership")
-```
-
-**Why:** Database-level enforcement is more reliable than application-level checks, especially under concurrent requests.
-
-### 3. **Nullable Title with Default**
-
-Meeting titles are optional but always returned as strings:
-
-```typescript
-title: result.title || 'Untitled Meeting';
-```
-
-**Why:** UX flexibility (quick meeting creation) while maintaining clean responses.
-
-### 4. **Ordered Member List**
-
-Members are always ordered by `joinedAt` ascending:
-
-```typescript
-orderBy: {
-  joinedAt: 'asc';
-}
-```
-
-**Why:** Host appears first, provides chronological context for join order.
-
-### 5. **Separate DTOs for Input/Output**
-
-Input DTOs use `class-validator`, output DTOs are plain interfaces:
-
-**Why:**
-
-- Input validation at HTTP layer
-- Type safety in responses
-- Clear separation of concerns
-
-### 6. **Repository for Transaction Support**
-
-`createMembershipWithinTransaction()` accepts `Prisma.TransactionClient`:
-
-```typescript
-async createMembershipWithinTransaction(
-  tx: Prisma.TransactionClient,
-  meetingId: string,
-  userId: string,
-  role: MeetingRole,
-)
-```
-
-**Why:** Enables atomic operations across multiple repositories if needed.
-
-## Testing Strategy
-
-### Unit Tests
-
-```typescript
-describe('MeetingsService', () => {
-  it('should create meeting with host membership');
-  it('should prevent duplicate joins');
-  it('should throw 404 for non-existent meeting');
-  it('should handle transaction rollback on failure');
-});
-```
-
-### Integration Tests
-
-```typescript
-describe('POST /meetings', () => {
-  it('should return 401 without auth token');
-  it('should create meeting and return 201');
-  it('should default title to "Untitled Meeting"');
-});
-
-describe('POST /meetings/:id/join', () => {
-  it('should add user as participant');
-  it('should return 409 if already joined');
-  it('should return 404 for invalid meeting');
-});
-```
-
-## Performance Considerations
-
-1. **Database Indexes**: All foreign keys and frequently queried fields indexed
-2. **Single Query for Details**: Uses Prisma `include` to fetch meeting + members + user names in one query
-3. **Selective Fields**: Only fetches needed user fields (`id`, `name`) instead of entire user objects
-4. **Early Validation**: Checks meeting existence before attempting to join
-
-## Future Enhancements
-
-### Phase 3: Advanced Features
-
-- [ ] Leave meeting endpoint
-- [ ] Kick member (HOST only)
-- [ ] Transfer host role
-- [ ] Meeting expiration/auto-close
-- [ ] Meeting capacity limits
-- [ ] Invitation links with tokens
-
-### Phase 4: Real-time Features
-
-- [ ] WebSocket events for member join/leave
-- [ ] Presence tracking (online/offline)
-- [ ] Typing indicators
-- [ ] Chat messages
-
-### Phase 5: Analytics
-
-- [ ] Meeting duration tracking
-- [ ] Member participation metrics
-- [ ] Meeting history
-
-## Example Flow
-
-1. **User A creates meeting:**
-
-   ```bash
-   POST /api/meetings
-   → Meeting created with ID: abc-123
-   → User A automatically added as HOST
-   ```
-
-2. **User B joins meeting:**
-
-   ```bash
-   POST /api/meetings/abc-123/join
-   → User B added as PARTICIPANT
-   → Returns full meeting details with members list
-   ```
-
-3. **User C gets meeting details:**
-
-   ```bash
-   GET /api/meetings/abc-123
-   → Returns meeting with all members:
-     - User A (HOST, joined first)
-     - User B (PARTICIPANT, joined second)
-   ```
-
-4. **User B tries to join again:**
-   ```bash
-   POST /api/meetings/abc-123/join
-   → 409 Conflict: Already a member
-   ```
-
-## Dependencies
-
-- **@nestjs/common**: HTTP decorators, exceptions
-- **@prisma/client**: Database ORM
-- **class-validator**: Input validation
-- **uuid**: Token generation (inherited from auth module)
+---
 
 ## Related Documentation
 
 - [Authentication Flow](./AUTH_API.md)
 - [Refresh Token Rotation](./REFRESH_TOKEN.md)
+- [Signaling Events](./signaling-events.md)
 - Database Schema: `prisma/schema.prisma`

--- a/docs/signaling-events.md
+++ b/docs/signaling-events.md
@@ -2,6 +2,38 @@
 
 Documentation for the Socket.IO signaling gateway.
 
+---
+
+## Client Flow (Google Meet–style)
+
+The backend is designed around a **pre-join / in-call** separation, similar to Google Meet:
+
+1. **User opens `/meet/:id`** — The client calls `GET /meetings/:id` to fetch meeting metadata (title, hostId). The user is **not** a participant yet; no WebSocket connection is needed at this stage.
+
+2. **Pre-join screen** — The client renders a lobby UI (camera/mic preview, display name, etc.). Optionally, the client may emit `watch-meeting` to observe the current participant list without entering the call.
+
+3. **User clicks "Join"** — The client establishes a WebSocket connection (if not already connected) and emits `join-room`. **Only after the server processes `join-room` does the user become an active participant.**
+
+4. **In-call** — The user is now tracked in-memory by `SignalingSessionService`. WebRTC negotiation (`offer`, `answer`, `ice-candidate`) is available. Presence updates (`participant-joined`, `participant-left`) are broadcast to the call room and any lobby watchers.
+
+5. **User leaves** — Either explicitly via `leave-room`, or implicitly via disconnect. The server removes the participant from memory and broadcasts `participant-left`.
+
+> **Key principle:** Presence is **ephemeral**. It exists only after `join-room` and is cleared on `leave-room` or disconnect. There is no persistent participant table in the database.
+
+---
+
+## Future Extensibility: Request-Join / Approval Flow
+
+The `join-room` handler delegates to an internal `canJoinMeeting()` method. This is the **single extension point** for adding join-gating logic in a future phase:
+
+- A `request-join` client event (reserved, **not yet implemented**) will allow a user to signal intent to join.
+- The host can approve or deny the request.
+- `canJoinMeeting()` will then check approval status before allowing the user into the call.
+
+No client changes are required until this flow is implemented.
+
+---
+
 ## Connection
 
 The gateway is available on the default Socket.IO namespace (`/`). Clients must authenticate at the handshake layer — **no messages are processed from unauthenticated sockets.**
@@ -63,11 +95,11 @@ Authenticated clients can join meeting rooms, watch the lobby, and receive prese
 
 ### Client → Server Events
 
-| Event           | Payload                 | Description                                                                                       |
-| --------------- | ----------------------- | ------------------------------------------------------------------------------------------------- |
-| `join-room`     | `{ meetingId: string }` | Join a meeting room. Server validates meeting existence and membership.                           |
-| `leave-room`    | `{ meetingId: string }` | Leave a meeting room. Server removes the socket and broadcasts departure.                         |
-| `watch-meeting` | `{ meetingId: string }` | Join the lobby watcher room (`watch:{meetingId}`). Receives current participant list immediately. |
+| Event           | Payload                 | Description                                                                                                                                                                                   |
+| --------------- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `join-room`     | `{ meetingId: string }` | Join the **active call** (in-call state). Server validates meeting existence via `canJoinMeeting()`. Any authenticated user may join. This is the only event that makes a user a participant. |
+| `leave-room`    | `{ meetingId: string }` | Leave the active call. Server removes the socket from the participant store and broadcasts departure.                                                                                         |
+| `watch-meeting` | `{ meetingId: string }` | **Optional lobby observer.** Joins the `watch:{meetingId}` room to receive the current participant list and live join/leave updates, without entering the call.                               |
 
 ### Server → Client Events
 
@@ -85,18 +117,18 @@ interface ParticipantInfo {
   userId: string;
   name: string;
   socketId: string;
+  isHost: boolean;
   joinedAt: Date;
 }
 ```
 
 ### Error Codes
 
-| Code  | Meaning                     |
-| ----- | --------------------------- |
-| `400` | Invalid or missing payload  |
-| `401` | Not authenticated           |
-| `403` | Not a member of the meeting |
-| `404` | Meeting not found           |
+| Code  | Meaning                    |
+| ----- | -------------------------- |
+| `400` | Invalid or missing payload |
+| `401` | Not authenticated          |
+| `404` | Meeting not found          |
 
 ### Example: Joining a Room
 
@@ -146,6 +178,7 @@ socket.on('participant-left', ({ participant }) => {
 
 ### Presence State
 
+- **Presence is ephemeral** — it only exists after `join-room` and is removed on `leave-room` or disconnect. There is no persistent participant table.
 - Presence is managed by `SignalingSessionService` — an injectable service with a typed interface designed to support Redis-backed adapters in a future phase.
 - When a socket disconnects (abruptly or gracefully), the server removes it from all rooms and broadcasts `participant-left` to both the call room and the `watch:{meetingId}` lobby.
 - When the last participant leaves, the meeting entry is cleared from the in-memory maps. The lobby room persists independently.
@@ -219,3 +252,4 @@ socket.on('offer', ({ fromSocketId, payload }) => {
 ## Out of Scope
 
 - Distributed presence (Redis adapter) — the `ISignalingSessionService` interface is designed to support this without gateway changes.
+- `request-join` / host-approval flow — the `canJoinMeeting()` extension point is in place; implementation is deferred to a future phase.

--- a/prisma/migrations/20260316094327_remove_meeting_member/migration.sql
+++ b/prisma/migrations/20260316094327_remove_meeting_member/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "meetings" (
+    "id" TEXT NOT NULL,
+    "title" TEXT,
+    "hostId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "meetings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "meetings_hostId_idx" ON "meetings"("hostId");
+
+-- AddForeignKey
+ALTER TABLE "meetings" ADD CONSTRAINT "meetings_hostId_fkey" FOREIGN KEY ("hostId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,7 +25,6 @@ model User {
   updatedAt     DateTime          @updatedAt
   refreshTokens RefreshToken[]
   hostedMeetings Meeting[]        @relation("MeetingHost")
-  meetingMembers MeetingMember[]
 
   @@map("users")
 }
@@ -47,11 +46,6 @@ enum UserRole {
   ADMIN
 }
 
-enum MeetingRole {
-  HOST
-  PARTICIPANT
-}
-
 model Meeting {
   id        String   @id @default(uuid())
   title     String?
@@ -60,24 +54,7 @@ model Meeting {
   
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
-  
-  members   MeetingMember[]
 
   @@index([hostId])
   @@map("meetings")
-}
-
-model MeetingMember {
-  id        String      @id @default(uuid())
-  meetingId String
-  meeting   Meeting     @relation(fields: [meetingId], references: [id], onDelete: Cascade)
-  userId    String
-  user      User        @relation(fields: [userId], references: [id], onDelete: Cascade)
-  role      MeetingRole
-  joinedAt  DateTime    @default(now())
-
-  @@unique([meetingId, userId], name: "unique_meeting_membership")
-  @@index([meetingId])
-  @@index([userId])
-  @@map("meeting_members")
 }

--- a/src/meetings/dto/join-meeting.dto.ts
+++ b/src/meetings/dto/join-meeting.dto.ts
@@ -1,6 +1,0 @@
-import { IsUUID } from 'class-validator';
-
-export class JoinMeetingDto {
-  @IsUUID()
-  meetingId!: string;
-}

--- a/src/meetings/dto/meeting-member.dto.ts
+++ b/src/meetings/dto/meeting-member.dto.ts
@@ -1,9 +1,0 @@
-import { MeetingRole } from '@prisma/client';
-
-export class MeetingMemberDto {
-  id!: string;
-  userId!: string;
-  userName!: string;
-  role!: MeetingRole;
-  joinedAt!: Date;
-}

--- a/src/meetings/dto/meeting-response.dto.ts
+++ b/src/meetings/dto/meeting-response.dto.ts
@@ -1,10 +1,7 @@
-import { MeetingMemberDto } from './meeting-member.dto';
-
 export class MeetingResponseDto {
   id!: string;
   title!: string;
   hostId!: string;
   createdAt!: Date;
   updatedAt!: Date;
-  members?: MeetingMemberDto[];
 }

--- a/src/meetings/meetings.controller.ts
+++ b/src/meetings/meetings.controller.ts
@@ -28,15 +28,6 @@ export class MeetingsController {
     return this.meetingsService.createMeeting(userId, createMeetingDto);
   }
 
-  @Post(':id/join')
-  @HttpCode(HttpStatus.OK)
-  async joinMeeting(
-    @CurrentUser('id') userId: string,
-    @Param('id') meetingId: string,
-  ): Promise<MeetingResponseDto> {
-    return this.meetingsService.joinMeeting(userId, meetingId);
-  }
-
   @Get(':id')
   @HttpCode(HttpStatus.OK)
   async getMeetingDetails(@Param('id') meetingId: string): Promise<MeetingResponseDto> {

--- a/src/meetings/meetings.repository.ts
+++ b/src/meetings/meetings.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../database/prisma.service';
-import { Meeting, MeetingRole, Prisma } from '@prisma/client';
+import { Meeting, Prisma } from '@prisma/client';
 
 @Injectable()
 export class MeetingsRepository {
@@ -16,33 +16,6 @@ export class MeetingsRepository {
     return this.prisma.meeting.findUnique({
       where: { id },
       include,
-    });
-  }
-
-  async createMembershipWithinTransaction(
-    tx: Prisma.TransactionClient,
-    meetingId: string,
-    userId: string,
-    role: MeetingRole,
-  ) {
-    return tx.meetingMember.create({
-      data: {
-        meetingId,
-        userId,
-        role,
-      },
-    });
-  }
-
-  async findMemberByMeetingAndUser(
-    meetingId: string,
-    userId: string,
-  ): Promise<{ id: string } | null> {
-    return this.prisma.meetingMember.findFirst({
-      where: {
-        AND: [{ meetingId }, { userId }],
-      },
-      select: { id: true },
     });
   }
 }

--- a/src/meetings/meetings.service.ts
+++ b/src/meetings/meetings.service.ts
@@ -1,17 +1,11 @@
-import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
-import { PrismaService } from '../database/prisma.service';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { MeetingsRepository } from './meetings.repository';
 import { CreateMeetingDto } from './dto/create-meeting.dto';
 import { MeetingResponseDto } from './dto/meeting-response.dto';
-import { MeetingMemberDto } from './dto/meeting-member.dto';
-import { MeetingRole } from '@prisma/client';
 
 @Injectable()
 export class MeetingsService {
-  constructor(
-    private readonly prisma: PrismaService,
-    private readonly meetingsRepository: MeetingsRepository,
-  ) {}
+  constructor(private readonly meetingsRepository: MeetingsRepository) {}
 
   async createMeeting(
     userId: string,
@@ -19,103 +13,10 @@ export class MeetingsService {
   ): Promise<MeetingResponseDto> {
     const { title } = createMeetingDto;
 
-    // Use transaction to ensure atomicity: create meeting + add host as member
-    const result = await this.prisma.$transaction(async (tx) => {
-      const meeting = await tx.meeting.create({
-        data: {
-          title: title || 'Untitled Meeting',
-          hostId: userId,
-        },
-      });
-
-      await this.meetingsRepository.createMembershipWithinTransaction(
-        tx,
-        meeting.id,
-        userId,
-        MeetingRole.HOST,
-      );
-
-      return meeting;
+    const meeting = await this.meetingsRepository.create({
+      title: title || 'Untitled Meeting',
+      host: { connect: { id: userId } },
     });
-
-    return {
-      id: result.id,
-      title: result.title || 'Untitled Meeting',
-      hostId: result.hostId,
-      createdAt: result.createdAt,
-      updatedAt: result.updatedAt,
-    };
-  }
-
-  async joinMeeting(userId: string, meetingId: string): Promise<MeetingResponseDto> {
-    // Check if meeting exists
-    const meeting = await this.meetingsRepository.findById(meetingId);
-    if (!meeting) {
-      throw new NotFoundException(`Meeting with ID ${meetingId} not found`);
-    }
-
-    // Check if user is already a member
-    const existingMember = await this.meetingsRepository.findMemberByMeetingAndUser(
-      meetingId,
-      userId,
-    );
-
-    if (existingMember) {
-      throw new ConflictException('You are already a member of this meeting');
-    }
-
-    // Add user as participant
-    await this.prisma.meetingMember.create({
-      data: {
-        meetingId,
-        userId,
-        role: MeetingRole.PARTICIPANT,
-      },
-    });
-
-    return this.getMeetingDetails(meetingId);
-  }
-
-  async getMeetingDetails(meetingId: string): Promise<MeetingResponseDto> {
-    const meeting = await this.meetingsRepository.findById(meetingId, {
-      members: {
-        include: {
-          user: {
-            select: {
-              id: true,
-              name: true,
-            },
-          },
-        },
-        orderBy: {
-          joinedAt: 'asc',
-        },
-      },
-    });
-
-    if (!meeting) {
-      throw new NotFoundException(`Meeting with ID ${meetingId} not found`);
-    }
-
-    // Type assertion since Prisma types can be complex with includes
-    const meetingWithMembers = meeting as typeof meeting & {
-      members: Array<{
-        id: string;
-        userId: string;
-        role: MeetingRole;
-        joinedAt: Date;
-        user: { id: string; name: string };
-      }>;
-    };
-
-    const members: MeetingMemberDto[] =
-      meetingWithMembers.members?.map((member) => ({
-        id: member.id,
-        userId: member.userId,
-        userName: member.user.name,
-        role: member.role,
-        joinedAt: member.joinedAt,
-      })) || [];
 
     return {
       id: meeting.id,
@@ -123,7 +24,22 @@ export class MeetingsService {
       hostId: meeting.hostId,
       createdAt: meeting.createdAt,
       updatedAt: meeting.updatedAt,
-      members,
+    };
+  }
+
+  async getMeetingDetails(meetingId: string): Promise<MeetingResponseDto> {
+    const meeting = await this.meetingsRepository.findById(meetingId);
+
+    if (!meeting) {
+      throw new NotFoundException(`Meeting with ID ${meetingId} not found`);
+    }
+
+    return {
+      id: meeting.id,
+      title: meeting.title || 'Untitled Meeting',
+      hostId: meeting.hostId,
+      createdAt: meeting.createdAt,
+      updatedAt: meeting.updatedAt,
     };
   }
 }

--- a/src/signaling/signaling-session.interface.ts
+++ b/src/signaling/signaling-session.interface.ts
@@ -4,6 +4,7 @@ export interface ParticipantInfo {
   socketId: string;
   userId: string;
   name: string;
+  isHost: boolean;
   joinedAt: number;
 }
 
@@ -19,6 +20,7 @@ export interface ISignalingSessionService {
     meetingId: string,
     socketId: string,
     user: Omit<User, 'passwordHash'>,
+    isHost: boolean,
   ): AddParticipantResult;
   removeParticipant(
     socketId: string,

--- a/src/signaling/signaling-session.service.spec.ts
+++ b/src/signaling/signaling-session.service.spec.ts
@@ -34,46 +34,57 @@ describe('SignalingSessionService', () => {
 
   describe('addParticipant', () => {
     it('should return a result with correct ParticipantInfo fields', () => {
-      const { participant } = service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+      const { participant } = service.addParticipant(MEETING_UUID, 'socket-1', fakeUser, true);
 
       expect(participant.socketId).toBe('socket-1');
       expect(participant.userId).toBe('user-1');
       expect(participant.name).toBe('Alice');
+      expect(participant.isHost).toBe(true);
       expect(typeof participant.joinedAt).toBe('number');
     });
 
     it('should return no evictedSocketId on fresh join', () => {
-      const { evictedSocketId } = service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+      const { evictedSocketId } = service.addParticipant(MEETING_UUID, 'socket-1', fakeUser, false);
       expect(evictedSocketId).toBeUndefined();
     });
 
     it('should make isParticipant return true after adding', () => {
-      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser, false);
       expect(service.isParticipant(MEETING_UUID, 'socket-1')).toBe(true);
     });
 
     it('should register the meeting in getMeetingIdBySocket for the socket', () => {
-      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser, false);
       expect(service.getMeetingIdBySocket('socket-1')).toBe(MEETING_UUID);
     });
 
     it('should track multiple sockets in the same room independently', () => {
-      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
-      service.addParticipant(MEETING_UUID, 'socket-2', fakeUser2);
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser, true);
+      service.addParticipant(MEETING_UUID, 'socket-2', fakeUser2, false);
 
       expect(service.isParticipant(MEETING_UUID, 'socket-1')).toBe(true);
       expect(service.isParticipant(MEETING_UUID, 'socket-2')).toBe(true);
     });
 
     it('should evict the old socket when the same userId joins with a new socket', () => {
-      service.addParticipant(MEETING_UUID, 'socket-old', fakeUser);
-      const { evictedSocketId } = service.addParticipant(MEETING_UUID, 'socket-new', fakeUser);
+      service.addParticipant(MEETING_UUID, 'socket-old', fakeUser, true);
+      const { evictedSocketId } = service.addParticipant(
+        MEETING_UUID,
+        'socket-new',
+        fakeUser,
+        true,
+      );
 
       expect(evictedSocketId).toBe('socket-old');
       expect(service.isParticipant(MEETING_UUID, 'socket-old')).toBe(false);
       expect(service.isParticipant(MEETING_UUID, 'socket-new')).toBe(true);
       expect(service.getMeetingIdBySocket('socket-old')).toBeUndefined();
       expect(service.getMeetingIdBySocket('socket-new')).toBe(MEETING_UUID);
+    });
+
+    it('should correctly set isHost=false for non-host participant', () => {
+      const { participant } = service.addParticipant(MEETING_UUID, 'socket-2', fakeUser2, false);
+      expect(participant.isHost).toBe(false);
     });
   });
 
@@ -86,7 +97,7 @@ describe('SignalingSessionService', () => {
     });
 
     it('should return { meetingId, participant } on successful removal', () => {
-      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser, false);
       const result = service.removeParticipant('socket-1');
 
       expect(result).toBeDefined();
@@ -96,29 +107,29 @@ describe('SignalingSessionService', () => {
     });
 
     it('should make isParticipant return false after removing', () => {
-      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser, false);
       service.removeParticipant('socket-1');
 
       expect(service.isParticipant(MEETING_UUID, 'socket-1')).toBe(false);
     });
 
     it('should clean up the room entry when the last participant leaves', () => {
-      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser, false);
       service.removeParticipant('socket-1');
 
       expect(service.getParticipants(MEETING_UUID)).toEqual([]);
     });
 
     it('should clear getMeetingIdBySocket after removal', () => {
-      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser, false);
       service.removeParticipant('socket-1');
 
       expect(service.getMeetingIdBySocket('socket-1')).toBeUndefined();
     });
 
     it('should not remove other participants when one leaves', () => {
-      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
-      service.addParticipant(MEETING_UUID, 'socket-2', fakeUser2);
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser, true);
+      service.addParticipant(MEETING_UUID, 'socket-2', fakeUser2, false);
       service.removeParticipant('socket-1');
 
       expect(service.isParticipant(MEETING_UUID, 'socket-2')).toBe(true);
@@ -133,8 +144,8 @@ describe('SignalingSessionService', () => {
     });
 
     it('should return the correct participants after adding', () => {
-      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
-      service.addParticipant(MEETING_UUID, 'socket-2', fakeUser2);
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser, true);
+      service.addParticipant(MEETING_UUID, 'socket-2', fakeUser2, false);
 
       const participants = service.getParticipants(MEETING_UUID);
 
@@ -153,7 +164,7 @@ describe('SignalingSessionService', () => {
     });
 
     it('should return the meeting id after joining', () => {
-      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser, false);
       expect(service.getMeetingIdBySocket('socket-1')).toBe(MEETING_UUID);
     });
   });
@@ -166,7 +177,7 @@ describe('SignalingSessionService', () => {
     });
 
     it('should return false for a socket not in the room', () => {
-      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser);
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser, false);
       expect(service.isParticipant(MEETING_UUID, 'socket-99')).toBe(false);
     });
   });

--- a/src/signaling/signaling-session.service.ts
+++ b/src/signaling/signaling-session.service.ts
@@ -15,6 +15,7 @@ export class SignalingSessionService implements ISignalingSessionService {
     meetingId: string,
     socketId: string,
     user: Omit<User, 'passwordHash'>,
+    isHost: boolean,
   ): AddParticipantResult {
     if (!this.rooms.has(meetingId)) {
       this.rooms.set(meetingId, new Map());
@@ -35,6 +36,7 @@ export class SignalingSessionService implements ISignalingSessionService {
       socketId,
       userId: user.id,
       name: user.name ?? 'Anonymous',
+      isHost,
       joinedAt: Date.now(),
     };
     room.set(socketId, participant);

--- a/src/signaling/signaling.gateway.spec.ts
+++ b/src/signaling/signaling.gateway.spec.ts
@@ -59,6 +59,7 @@ const fakeParticipant: ParticipantInfo = {
   socketId: 'socket-1',
   userId: 'user-1',
   name: 'Alice',
+  isHost: true,
   joinedAt: 0,
 };
 
@@ -66,6 +67,7 @@ const fakeParticipant2: ParticipantInfo = {
   socketId: 'socket-2',
   userId: 'user-2',
   name: 'Bob',
+  isHost: false,
   joinedAt: 0,
 };
 
@@ -73,7 +75,7 @@ const fakeParticipant2: ParticipantInfo = {
 
 describe('SignalingGateway', () => {
   let gateway: SignalingGateway;
-  let meetingsRepository: { findById: jest.Mock; findMemberByMeetingAndUser: jest.Mock };
+  let meetingsRepository: { findById: jest.Mock };
   let jwtService: { verify: jest.Mock };
   let usersRepository: { findById: jest.Mock };
   let mockSessionService: {
@@ -89,7 +91,6 @@ describe('SignalingGateway', () => {
   beforeEach(async () => {
     meetingsRepository = {
       findById: jest.fn(),
-      findMemberByMeetingAndUser: jest.fn(),
     };
     jwtService = { verify: jest.fn() };
     usersRepository = { findById: jest.fn() };
@@ -224,25 +225,12 @@ describe('SignalingGateway', () => {
       });
     });
 
-    it('should emit 403 when user is not a member', async () => {
-      const socket = createMockSocket();
-      socket.data.user = fakeUser as never;
-      meetingsRepository.findById.mockResolvedValue({ id: MEETING_UUID });
-      meetingsRepository.findMemberByMeetingAndUser.mockResolvedValue(null);
-      await gateway.handleJoinRoom({ meetingId: MEETING_UUID }, socket);
-      expect(socket.emit).toHaveBeenCalledWith('error', {
-        code: 403,
-        message: 'Not a member of this meeting',
-      });
-    });
-
     it('should be a no-op when socket is already in the room', async () => {
       const socket = createMockSocket();
       socket.data.user = fakeUser as never;
-      meetingsRepository.findById.mockResolvedValue({ id: MEETING_UUID });
-      meetingsRepository.findMemberByMeetingAndUser.mockResolvedValue({ id: 'member-1' });
       mockSessionService.isParticipant.mockReturnValue(true);
       await gateway.handleJoinRoom({ meetingId: MEETING_UUID }, socket);
+      expect(meetingsRepository.findById).not.toHaveBeenCalled();
       expect(socket.join).not.toHaveBeenCalled();
       expect(mockSessionService.addParticipant).not.toHaveBeenCalled();
     });
@@ -250,8 +238,7 @@ describe('SignalingGateway', () => {
     it('should join room, call addParticipant, broadcast, and emit participants-list', async () => {
       const socket = createMockSocket();
       socket.data.user = fakeUser as never;
-      meetingsRepository.findById.mockResolvedValue({ id: MEETING_UUID });
-      meetingsRepository.findMemberByMeetingAndUser.mockResolvedValue({ id: 'member-1' });
+      meetingsRepository.findById.mockResolvedValue({ id: MEETING_UUID, hostId: 'user-1' });
       mockSessionService.isParticipant.mockReturnValue(false);
       mockSessionService.addParticipant.mockReturnValue({ participant: fakeParticipant });
       mockSessionService.getParticipants.mockReturnValue([fakeParticipant]);
@@ -263,13 +250,14 @@ describe('SignalingGateway', () => {
         MEETING_UUID,
         'socket-1',
         expect.objectContaining({ id: 'user-1' }),
+        true,
       );
       expect(socket.to).toHaveBeenCalledWith(MEETING_UUID);
       expect(socket._broadcast.emit).toHaveBeenCalledWith(
         'participant-joined',
         expect.objectContaining({
           meetingId: MEETING_UUID,
-          participant: expect.objectContaining({ userId: 'user-1', name: 'Alice' }),
+          participant: expect.objectContaining({ userId: 'user-1', name: 'Alice', isHost: true }),
         }),
       );
       expect(socket.emit).toHaveBeenCalledWith(
@@ -368,23 +356,10 @@ describe('SignalingGateway', () => {
       });
     });
 
-    it('should emit 403 when user is not a member of the meeting', async () => {
-      const socket = createMockSocket();
-      socket.data.user = fakeUser as never;
-      meetingsRepository.findById.mockResolvedValue({ id: MEETING_UUID });
-      meetingsRepository.findMemberByMeetingAndUser.mockResolvedValue(null);
-      await gateway.handleWatchMeeting({ meetingId: MEETING_UUID }, socket);
-      expect(socket.emit).toHaveBeenCalledWith('error', {
-        code: 403,
-        message: 'Not a member of this meeting',
-      });
-    });
-
     it('should join watch room and emit current participants-list on success', async () => {
       const socket = createMockSocket();
       socket.data.user = fakeUser as never;
-      meetingsRepository.findById.mockResolvedValue({ id: MEETING_UUID });
-      meetingsRepository.findMemberByMeetingAndUser.mockResolvedValue({ id: 'member-1' });
+      meetingsRepository.findById.mockResolvedValue({ id: MEETING_UUID, hostId: 'user-1' });
       mockSessionService.getParticipants.mockReturnValue([fakeParticipant]);
       await gateway.handleWatchMeeting({ meetingId: MEETING_UUID }, socket);
       expect(socket.join).toHaveBeenCalledWith('watch:' + MEETING_UUID);

--- a/src/signaling/signaling.gateway.ts
+++ b/src/signaling/signaling.gateway.ts
@@ -139,20 +139,8 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
 
     const { meetingId } = dto;
 
-    const meeting = await this.meetingsRepository.findById(meetingId);
-    if (!meeting) {
-      socket.emit('error', { code: 404, message: `Meeting ${meetingId} not found` });
-      return;
-    }
-
-    const membership = await this.meetingsRepository.findMemberByMeetingAndUser(
-      meetingId,
-      socket.data.user.id,
-    );
-    if (!membership) {
-      socket.emit('error', { code: 403, message: 'Not a member of this meeting' });
-      return;
-    }
+    const meeting = await this.resolveAndValidateMeeting(meetingId, socket);
+    if (!meeting) return;
 
     await socket.join(`watch:${meetingId}`);
     this.logger.log(
@@ -181,26 +169,20 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
 
     const { meetingId } = dto;
 
-    const meeting = await this.meetingsRepository.findById(meetingId);
-    if (!meeting) {
-      socket.emit('error', { code: 404, message: `Meeting ${meetingId} not found` });
-      return;
-    }
-
-    const membership = await this.meetingsRepository.findMemberByMeetingAndUser(meetingId, user.id);
-    if (!membership) {
-      socket.emit('error', { code: 403, message: 'Not a member of this meeting' });
-      return;
-    }
-
     // No-op if already present — prevents duplicate participant-joined broadcasts
     if (this.sessionService.isParticipant(meetingId, socket.id)) return;
+
+    const meeting = await this.canJoinMeeting(meetingId, user, socket);
+    if (!meeting) return;
+
+    const isHost = user.id === meeting.hostId;
 
     await socket.join(meetingId);
     const { participant, evictedSocketId } = this.sessionService.addParticipant(
       meetingId,
       socket.id,
       user,
+      isHost,
     );
 
     if (evictedSocketId) {
@@ -319,6 +301,53 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
 
   private cleanupSocket(socket: AuthenticatedSocket): void {
     this.removeFromRoomAndBroadcast(socket);
+  }
+
+  // ── Join-gating ────────────────────────────────────────────────────────
+  // These two methods form the single extension point for future join-flow
+  // changes (e.g. request-join / host-approval). All meeting-existence and
+  // authorization checks are funnelled through here so the handler methods
+  // stay thin.
+
+  /**
+   * Resolve a meeting by ID and emit a 404 error on the socket if it does
+   * not exist. Used by both `handleWatchMeeting` and `canJoinMeeting`.
+   */
+  private async resolveAndValidateMeeting(
+    meetingId: string,
+    socket: AuthenticatedSocket,
+  ): Promise<Awaited<ReturnType<MeetingsRepository['findById']>> | null> {
+    const meeting = await this.meetingsRepository.findById(meetingId);
+    if (!meeting) {
+      socket.emit('error', { code: 404, message: `Meeting ${meetingId} not found` });
+      return null;
+    }
+    return meeting;
+  }
+
+  /**
+   * Determine whether a user is allowed to enter the active call.
+   *
+   * Currently any authenticated user with a valid meeting ID may join
+   * (stateless, Google Meet–style). To add an approval gate in the future,
+   * insert the check here — for example:
+   *
+   * ```ts
+   * if (await this.joinApprovalService.isPending(meetingId, user.id)) {
+   *   socket.emit('error', { code: 403, message: 'Waiting for host approval' });
+   *   return null;
+   * }
+   * ```
+   *
+   * @returns The meeting record when join is permitted, or `null` if the
+   *          request was rejected (error already emitted to the socket).
+   */
+  private async canJoinMeeting(
+    meetingId: string,
+    _user: Omit<User, 'passwordHash'>,
+    socket: AuthenticatedSocket,
+  ): Promise<Awaited<ReturnType<MeetingsRepository['findById']>> | null> {
+    return this.resolveAndValidateMeeting(meetingId, socket);
   }
 
   private validateSocketPayload<T extends object>(


### PR DESCRIPTION
## Description
- Refactor signaling flow to separate pre-join (lobby/watch) from in-call (join-room) presence.
- Add canJoinMeeting() as a single extension point for future approval gating.
- Keep session state in-memory and created only after join-room.

## Test plan
- [x] Run pnpm build (no type errors).
- [x] Run pnpm test (all suites pass).
- [x] Verify join-room adds a participant and leave-room/disconnect removes it.