### PR TITLE
feat(signaling): add participant media state event support

### DIFF
--- a/docs/signaling-events.md
+++ b/docs/signaling-events.md
@@ -95,32 +95,38 @@ Authenticated clients can join meeting rooms, watch the lobby, and receive prese
 
 ### Client → Server Events
 
-| Event           | Payload                 | Description                                                                                                                                                                                   |
-| --------------- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `join-room`     | `{ meetingId: string }` | Join the **active call** (in-call state). Server validates meeting existence via `canJoinMeeting()`. Any authenticated user may join. This is the only event that makes a user a participant. |
-| `leave-room`    | `{ meetingId: string }` | Leave the active call. Server removes the socket from the participant store and broadcasts departure.                                                                                         |
-| `watch-meeting` | `{ meetingId: string }` | **Optional lobby observer.** Joins the `watch:{meetingId}` room to receive the current participant list and live join/leave updates, without entering the call.                               |
+| Event                     | Payload                                                 | Description                                                                                                                                                                                   |
+| ------------------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `join-room`               | `{ meetingId: string }`                                 | Join the **active call** (in-call state). Server validates meeting existence via `canJoinMeeting()`. Any authenticated user may join. This is the only event that makes a user a participant. |
+| `leave-room`              | `{ meetingId: string }`                                 | Leave the active call. Server removes the socket from the participant store and broadcasts departure.                                                                                         |
+| `watch-meeting`           | `{ meetingId: string }`                                 | **Optional lobby observer.** Joins the `watch:{meetingId}` room to receive the current participant list and live join/leave updates, without entering the call.                               |
+| `participant-media-state` | `{ meetingId: string, video: boolean, audio: boolean }` | Notify the server that the sender toggled camera and/or mic. Server updates its in-memory state and broadcasts to all **other** participants.                                                 |
 
 ### Server → Client Events
 
-| Event                | Payload                                                  | Description                                                                                                              |
-| -------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `participant-joined` | `{ meetingId: string, participant: ParticipantInfo }`    | Broadcast to all members of the call room and the `watch:{meetingId}` lobby when a new participant joins.                |
-| `participant-left`   | `{ meetingId: string, participant: ParticipantInfo }`    | Broadcast to all members of the call room and the `watch:{meetingId}` lobby when a participant leaves or disconnects.    |
-| `participants-list`  | `{ meetingId: string, participants: ParticipantInfo[] }` | Sent automatically to the joining socket after `join-room`, and immediately to the watcher socket after `watch-meeting`. |
-| `error`              | `{ code: number, message: string }`                      | Error response (e.g., 401, 403, 404).                                                                                    |
+| Event                     | Payload                                                                 | Description                                                                                                              |
+| ------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `participant-joined`      | `{ meetingId: string, participant: ParticipantInfo }`                   | Broadcast to all members of the call room and the `watch:{meetingId}` lobby when a new participant joins.                |
+| `participant-left`        | `{ meetingId: string, participant: ParticipantInfo }`                   | Broadcast to all members of the call room and the `watch:{meetingId}` lobby when a participant leaves or disconnects.    |
+| `participants-list`       | `{ meetingId: string, participants: ParticipantInfo[] }`                | Sent automatically to the joining socket after `join-room`, and immediately to the watcher socket after `watch-meeting`. |
+| `participant-media-state` | `{ meetingId: string, userId: string, video: boolean, audio: boolean }` | Broadcast to all **other** participants when one participant changes their camera or mic state. Sender is not echoed.    |
+| `error`                   | `{ code: number, message: string }`                                     | Error response (e.g., 401, 403, 404, 500).                                                                               |
 
 ### `ParticipantInfo`
 
 ```typescript
 interface ParticipantInfo {
+  socketId: string;
   userId: string;
   name: string;
-  socketId: string;
   isHost: boolean;
-  joinedAt: Date;
+  joinedAt: number; // Unix timestamp (Date.now())
+  isVideoEnabled: boolean; // camera on/off
+  isAudioEnabled: boolean; // mic on/off
 }
 ```
+
+Media state defaults to `false` when a participant joins. It is updated in real time via the `participant-media-state` event.
 
 ### Error Codes
 
@@ -128,7 +134,9 @@ interface ParticipantInfo {
 | ----- | -------------------------- |
 | `400` | Invalid or missing payload |
 | `401` | Not authenticated          |
+| `403` | Not in the room            |
 | `404` | Meeting not found          |
+| `500` | Internal state error       |
 
 ### Example: Joining a Room
 
@@ -136,23 +144,46 @@ interface ParticipantInfo {
 // After connecting with a valid JWT...
 socket.emit('join-room', { meetingId: 'meeting-uuid' });
 
-// The server automatically sends the current participant list to the joining socket.
+// The server automatically sends the current participant list (with media state) to the joining socket.
 socket.on('participants-list', ({ meetingId, participants }) => {
+  // Each participant includes isVideoEnabled and isAudioEnabled
   console.log(`Current participants in ${meetingId}:`, participants);
+  renderVideoGrid(participants);
 });
 
-// Listen for other participants joining
+// New participants arrive with their initial media state (both false)
 socket.on('participant-joined', ({ meetingId, participant }) => {
   console.log(`${participant.name} joined meeting ${meetingId}`);
+  addTile(participant); // tile renders even if camera is off
 });
 
 // Listen for participants leaving
 socket.on('participant-left', ({ meetingId, participant }) => {
   console.log(`${participant.name} left meeting ${meetingId}`);
+  removeTile(participant.userId);
+});
+
+// Receive real-time camera/mic toggles from other participants
+socket.on('participant-media-state', ({ meetingId, userId, video, audio }) => {
+  updateTileMediaState(userId, { video, audio });
 });
 
 // Leave a room explicitly
 socket.emit('leave-room', { meetingId: 'meeting-uuid' });
+```
+
+### Example: Toggling Camera / Mic
+
+```js
+// Called when the local user toggles their camera or mic
+function onLocalMediaToggle(isCameraOn, isMicOn) {
+  socket.emit('participant-media-state', {
+    meetingId: 'meeting-uuid',
+    video: isCameraOn,
+    audio: isMicOn,
+  });
+  // No need to handle an echo — the server does NOT emit back to the sender.
+}
 ```
 
 ### Example: Watching the Lobby
@@ -161,7 +192,7 @@ socket.emit('leave-room', { meetingId: 'meeting-uuid' });
 // Watch participant list without joining the call (e.g. pre-call lobby screen)
 socket.emit('watch-meeting', { meetingId: 'meeting-uuid' });
 
-// Server immediately sends the current participant list
+// Server immediately sends the current participant list (includes media state)
 socket.on('participants-list', ({ meetingId, participants }) => {
   console.log(`Lobby sees ${participants.length} participant(s)`);
 });

--- a/docs/socket-signaling.md
+++ b/docs/socket-signaling.md
@@ -79,9 +79,14 @@ interface ParticipantInfo {
   socketId: string;
   userId: string;
   name: string;
+  isHost: boolean;
   joinedAt: number; // Unix timestamp (Date.now())
+  isVideoEnabled: boolean; // camera on/off — always present, defaults to false
+  isAudioEnabled: boolean; // mic on/off — always present, defaults to false
 }
 ```
+
+Media state is managed by the server. It defaults to `false` on join and is updated in real time via `participant-media-state`.
 
 ---
 
@@ -143,6 +148,36 @@ Leave the video call explicitly.
 
 ---
 
+### `participant-media-state` (client → server)
+
+Notify the server that the local user toggled their camera or mic. The server updates its in-memory state and broadcasts the new state to all **other** participants (sender is never echoed back).
+
+**Payload:**
+
+```json
+{
+  "meetingId": "abc123",
+  "video": true,
+  "audio": false
+}
+```
+
+**Validation rules:**
+
+| Field       | Rule                               |
+| ----------- | ---------------------------------- |
+| `meetingId` | Required, non-empty, valid UUID v4 |
+| `video`     | Required, boolean                  |
+| `audio`     | Required, boolean                  |
+
+**Server behavior:**
+
+1. Validates the sender is an active participant in `meetingId` (403 if not).
+2. Updates `isVideoEnabled` and `isAudioEnabled` on the in-memory `ParticipantInfo`.
+3. Broadcasts `participant-media-state` to all **other** sockets in `{meetingId}` (sender excluded).
+
+---
+
 ### `offer`
 
 Relay a WebRTC offer to a specific peer.
@@ -197,7 +232,7 @@ Relay an ICE candidate to a specific peer.
 
 ### `participants-list`
 
-Sent to the socket that emitted `watch-meeting` or `join-room`.
+Sent to the socket that emitted `watch-meeting` or `join-room`. Includes the **full current media state** of every participant so the client can render the correct UI immediately (camera on/off tiles, mute indicators, etc.).
 
 **Payload:**
 
@@ -209,13 +244,19 @@ Sent to the socket that emitted `watch-meeting` or `join-room`.
       "socketId": "socket-abc",
       "userId": "user-uuid-1",
       "name": "Alice",
-      "joinedAt": 1741651200000
+      "isHost": true,
+      "joinedAt": 1741651200000,
+      "isVideoEnabled": true,
+      "isAudioEnabled": false
     },
     {
       "socketId": "socket-def",
       "userId": "user-uuid-2",
       "name": "Bob",
-      "joinedAt": 1741651205000
+      "isHost": false,
+      "joinedAt": 1741651205000,
+      "isVideoEnabled": false,
+      "isAudioEnabled": true
     }
   ]
 }
@@ -225,7 +266,7 @@ Sent to the socket that emitted `watch-meeting` or `join-room`.
 
 ### `participant-joined`
 
-Broadcast to all sockets in `{meetingId}` **and** `watch:{meetingId}` when a new participant joins the video call.
+Broadcast to all sockets in `{meetingId}` **and** `watch:{meetingId}` when a new participant joins the video call. New participants always join with `isVideoEnabled: false` and `isAudioEnabled: false`.
 
 **Payload:**
 
@@ -236,7 +277,10 @@ Broadcast to all sockets in `{meetingId}` **and** `watch:{meetingId}` when a new
     "socketId": "socket-abc",
     "userId": "user-uuid-1",
     "name": "Alice",
-    "joinedAt": 1741651200000
+    "isHost": false,
+    "joinedAt": 1741651200000,
+    "isVideoEnabled": false,
+    "isAudioEnabled": false
   }
 }
 ```
@@ -256,8 +300,28 @@ Broadcast to all sockets in `{meetingId}` **and** `watch:{meetingId}` when a par
     "socketId": "socket-abc",
     "userId": "user-uuid-1",
     "name": "Alice",
-    "joinedAt": 1741651200000
+    "isHost": false,
+    "joinedAt": 1741651200000,
+    "isVideoEnabled": true,
+    "isAudioEnabled": false
   }
+}
+```
+
+---
+
+### `participant-media-state` (server → client)
+
+Broadcast to all **other** participants in `{meetingId}` when one participant toggles their camera or mic. The sender does **not** receive this event.
+
+**Payload:**
+
+```json
+{
+  "meetingId": "abc123",
+  "userId": "user-uuid-1",
+  "video": true,
+  "audio": false
 }
 ```
 
@@ -294,6 +358,7 @@ Emitted to the socket that caused the error.
 | `401` | Not authenticated                             |
 | `403` | Not a member of the meeting / not in the room |
 | `404` | Meeting or target socket not found            |
+| `500` | Internal state error (e.g. media state write) |
 
 ---
 
@@ -329,12 +394,35 @@ socket.on('participant-left', ({ participant }) => {
 // Join from lobby (still watching) or fresh connection
 socket.emit('join-room', { meetingId: 'abc123' });
 
-// Receive the current list including yourself
+// Receive the current list — each participant includes isVideoEnabled / isAudioEnabled
 socket.on('participants-list', ({ participants }) => {
+  // Render a tile for every participant, even those with camera off
   initVideoGrid(participants);
 });
 
-// Others are notified via participant-joined
+// Others are notified; new joiners always start with video/audio = false
+socket.on('participant-joined', ({ participant }) => {
+  addTile(participant);
+});
+
+// Sync camera/mic state changes from other participants in real time
+socket.on('participant-media-state', ({ userId, video, audio }) => {
+  updateTileMediaState(userId, { video, audio });
+});
+```
+
+### Toggling camera / mic
+
+```js
+// After joining a room, send your media state whenever it changes.
+function onLocalMediaToggle(isCameraOn, isMicOn) {
+  socket.emit('participant-media-state', {
+    meetingId: 'abc123',
+    video: isCameraOn,
+    audio: isMicOn,
+  });
+  // Server does NOT echo back to the sender — update local UI directly.
+}
 ```
 
 ### WebRTC peer negotiation

--- a/src/signaling/dto/participant-media-state.dto.ts
+++ b/src/signaling/dto/participant-media-state.dto.ts
@@ -1,0 +1,14 @@
+import { IsBoolean, IsNotEmpty, IsString, IsUUID } from 'class-validator';
+
+export class ParticipantMediaStateDto {
+  @IsString()
+  @IsNotEmpty()
+  @IsUUID()
+  meetingId!: string;
+
+  @IsBoolean()
+  video!: boolean;
+
+  @IsBoolean()
+  audio!: boolean;
+}

--- a/src/signaling/signaling-session.interface.ts
+++ b/src/signaling/signaling-session.interface.ts
@@ -6,6 +6,8 @@ export interface ParticipantInfo {
   name: string;
   isHost: boolean;
   joinedAt: number;
+  isVideoEnabled: boolean;
+  isAudioEnabled: boolean;
 }
 
 export interface AddParticipantResult {
@@ -28,4 +30,9 @@ export interface ISignalingSessionService {
   getParticipants(meetingId: string): ParticipantInfo[];
   getMeetingIdBySocket(socketId: string): string | undefined;
   isParticipant(meetingId: string, socketId: string): boolean;
+  updateMediaState(
+    socketId: string,
+    video: boolean,
+    audio: boolean,
+  ): { meetingId: string; participant: ParticipantInfo } | undefined;
 }

--- a/src/signaling/signaling-session.service.spec.ts
+++ b/src/signaling/signaling-session.service.spec.ts
@@ -1,7 +1,6 @@
 import { SignalingSessionService } from './signaling-session.service';
 
 const MEETING_UUID = '11111111-1111-4111-a111-111111111111';
-const MEETING_UUID_2 = '22222222-2222-4222-a222-222222222222';
 
 const fakeUser = {
   id: 'user-1',
@@ -166,6 +165,70 @@ describe('SignalingSessionService', () => {
     it('should return the meeting id after joining', () => {
       service.addParticipant(MEETING_UUID, 'socket-1', fakeUser, false);
       expect(service.getMeetingIdBySocket('socket-1')).toBe(MEETING_UUID);
+    });
+  });
+
+  // ── addParticipant — media state defaults ────────────────────────────
+
+  describe('addParticipant — media state defaults', () => {
+    it('should initialize isVideoEnabled to false', () => {
+      const { participant } = service.addParticipant(MEETING_UUID, 'socket-1', fakeUser, true);
+      expect(participant.isVideoEnabled).toBe(false);
+    });
+
+    it('should initialize isAudioEnabled to false', () => {
+      const { participant } = service.addParticipant(MEETING_UUID, 'socket-1', fakeUser, true);
+      expect(participant.isAudioEnabled).toBe(false);
+    });
+  });
+
+  // ── updateMediaState ──────────────────────────────────────────────────
+
+  describe('updateMediaState', () => {
+    it('should return undefined for an unknown socketId', () => {
+      const result = service.updateMediaState('ghost-socket', true, true);
+      expect(result).toBeUndefined();
+    });
+
+    it('should return { meetingId, participant } and update video/audio flags', () => {
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser, false);
+      const result = service.updateMediaState('socket-1', true, true);
+
+      expect(result).toBeDefined();
+      expect(result!.meetingId).toBe(MEETING_UUID);
+      expect(result!.participant.isVideoEnabled).toBe(true);
+      expect(result!.participant.isAudioEnabled).toBe(true);
+    });
+
+    it('should persist updated state in getParticipants', () => {
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser, false);
+      service.updateMediaState('socket-1', true, false);
+
+      const [p] = service.getParticipants(MEETING_UUID);
+      expect(p.isVideoEnabled).toBe(true);
+      expect(p.isAudioEnabled).toBe(false);
+    });
+
+    it('should only update the targeted socket, not other participants', () => {
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser, true);
+      service.addParticipant(MEETING_UUID, 'socket-2', fakeUser2, false);
+      service.updateMediaState('socket-1', true, true);
+
+      const participants = service.getParticipants(MEETING_UUID);
+      const p2 = participants.find((p) => p.socketId === 'socket-2')!;
+      expect(p2.isVideoEnabled).toBe(false);
+      expect(p2.isAudioEnabled).toBe(false);
+    });
+
+    it('should reflect last-write-wins on rapid toggles', () => {
+      service.addParticipant(MEETING_UUID, 'socket-1', fakeUser, false);
+      service.updateMediaState('socket-1', true, true);
+      service.updateMediaState('socket-1', false, false);
+      service.updateMediaState('socket-1', true, false);
+
+      const result = service.updateMediaState('socket-1', false, true);
+      expect(result!.participant.isVideoEnabled).toBe(false);
+      expect(result!.participant.isAudioEnabled).toBe(true);
     });
   });
 

--- a/src/signaling/signaling-session.service.ts
+++ b/src/signaling/signaling-session.service.ts
@@ -38,6 +38,8 @@ export class SignalingSessionService implements ISignalingSessionService {
       name: user.name ?? 'Anonymous',
       isHost,
       joinedAt: Date.now(),
+      isVideoEnabled: false,
+      isAudioEnabled: false,
     };
     room.set(socketId, participant);
     this.socketToMeeting.set(socketId, meetingId);
@@ -68,5 +70,20 @@ export class SignalingSessionService implements ISignalingSessionService {
 
   isParticipant(meetingId: string, socketId: string): boolean {
     return this.rooms.get(meetingId)?.has(socketId) ?? false;
+  }
+
+  updateMediaState(
+    socketId: string,
+    video: boolean,
+    audio: boolean,
+  ): { meetingId: string; participant: ParticipantInfo } | undefined {
+    const meetingId = this.socketToMeeting.get(socketId);
+    if (!meetingId) return undefined;
+    const room = this.rooms.get(meetingId);
+    const participant = room?.get(socketId);
+    if (!participant) return undefined;
+    participant.isVideoEnabled = video;
+    participant.isAudioEnabled = audio;
+    return { meetingId, participant };
   }
 }

--- a/src/signaling/signaling.gateway.spec.ts
+++ b/src/signaling/signaling.gateway.spec.ts
@@ -13,7 +13,6 @@ import type { ParticipantInfo } from './signaling-session.interface';
 // ── Constants ──────────────────────────────────────────────────────────────
 
 const MEETING_UUID = '11111111-1111-4111-a111-111111111111';
-const MEETING_UUID_2 = '22222222-2222-4222-a222-222222222222';
 const TARGET_SOCKET_ID = 'socket-target';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -61,17 +60,9 @@ const fakeParticipant: ParticipantInfo = {
   name: 'Alice',
   isHost: true,
   joinedAt: 0,
+  isVideoEnabled: false,
+  isAudioEnabled: false,
 };
-
-const fakeParticipant2: ParticipantInfo = {
-  socketId: 'socket-2',
-  userId: 'user-2',
-  name: 'Bob',
-  isHost: false,
-  joinedAt: 0,
-};
-
-// ── Test suite ─────────────────────────────────────────────────────────────
 
 describe('SignalingGateway', () => {
   let gateway: SignalingGateway;
@@ -84,6 +75,7 @@ describe('SignalingGateway', () => {
     getParticipants: jest.Mock;
     getMeetingIdBySocket: jest.Mock;
     isParticipant: jest.Mock;
+    updateMediaState: jest.Mock;
   };
   let mockRateLimiter: { check: jest.Mock; clearSocket: jest.Mock };
   let mockServerToChain: { to: jest.Mock; emit: jest.Mock };
@@ -100,6 +92,7 @@ describe('SignalingGateway', () => {
       getParticipants: jest.fn().mockReturnValue([]),
       getMeetingIdBySocket: jest.fn().mockReturnValue(undefined),
       isParticipant: jest.fn().mockReturnValue(false),
+      updateMediaState: jest.fn().mockReturnValue(undefined),
     };
     mockRateLimiter = {
       check: jest.fn().mockReturnValue(true),
@@ -497,6 +490,91 @@ describe('SignalingGateway', () => {
       expect(socket.emit).toHaveBeenCalledWith('error', {
         code: 429,
         message: 'Too many signaling events',
+      });
+    });
+  });
+
+  // ── participant-media-state ────────────────────────────────────────────
+
+  describe('handleParticipantMediaState', () => {
+    it('should emit 401 when socket has no user', () => {
+      const socket = createMockSocket();
+      socket.data.user = undefined;
+      gateway.handleParticipantMediaState(
+        { meetingId: MEETING_UUID, video: true, audio: false },
+        socket,
+      );
+      expect(socket.emit).toHaveBeenCalledWith('error', {
+        code: 401,
+        message: 'Not authenticated',
+      });
+    });
+
+    it('should emit 400 when meetingId is not a valid UUID', () => {
+      const socket = createMockSocket();
+      socket.data.user = fakeUser as never;
+      gateway.handleParticipantMediaState(
+        { meetingId: 'not-a-uuid', video: true, audio: false },
+        socket,
+      );
+      expect(socket.emit).toHaveBeenCalledWith('error', expect.objectContaining({ code: 400 }));
+    });
+
+    it('should emit 403 when socket is not in the room', () => {
+      const socket = createMockSocket();
+      socket.data.user = fakeUser as never;
+      mockSessionService.isParticipant.mockReturnValue(false);
+      gateway.handleParticipantMediaState(
+        { meetingId: MEETING_UUID, video: true, audio: false },
+        socket,
+      );
+      expect(socket.emit).toHaveBeenCalledWith('error', {
+        code: 403,
+        message: 'You are not in this room',
+      });
+      expect(mockSessionService.updateMediaState).not.toHaveBeenCalled();
+    });
+
+    it('should update state and broadcast to room (not sender)', () => {
+      const socket = createMockSocket();
+      socket.data.user = fakeUser as never;
+      mockSessionService.isParticipant.mockReturnValue(true);
+      mockSessionService.updateMediaState.mockReturnValue({
+        meetingId: MEETING_UUID,
+        participant: { ...fakeParticipant, isVideoEnabled: true, isAudioEnabled: false },
+      });
+
+      gateway.handleParticipantMediaState(
+        { meetingId: MEETING_UUID, video: true, audio: false },
+        socket,
+      );
+
+      expect(mockSessionService.updateMediaState).toHaveBeenCalledWith('socket-1', true, false);
+      expect(socket.to).toHaveBeenCalledWith(MEETING_UUID);
+      expect(socket._broadcast.emit).toHaveBeenCalledWith('participant-media-state', {
+        meetingId: MEETING_UUID,
+        userId: 'user-1',
+        video: true,
+        audio: false,
+      });
+      // Sender should NOT receive an echo
+      expect(socket.emit).not.toHaveBeenCalled();
+    });
+
+    it('should emit 500 when updateMediaState returns undefined', () => {
+      const socket = createMockSocket();
+      socket.data.user = fakeUser as never;
+      mockSessionService.isParticipant.mockReturnValue(true);
+      mockSessionService.updateMediaState.mockReturnValue(undefined);
+
+      gateway.handleParticipantMediaState(
+        { meetingId: MEETING_UUID, video: false, audio: true },
+        socket,
+      );
+
+      expect(socket.emit).toHaveBeenCalledWith('error', {
+        code: 500,
+        message: 'Failed to update media state',
       });
     });
   });

--- a/src/signaling/signaling.gateway.ts
+++ b/src/signaling/signaling.gateway.ts
@@ -25,6 +25,7 @@ import { LeaveRoomDto } from './dto/leave-room.dto';
 import { OfferDto } from './dto/offer.dto';
 import { AnswerDto } from './dto/answer.dto';
 import { IceCandidateDto } from './dto/ice-candidate.dto';
+import { ParticipantMediaStateDto } from './dto/participant-media-state.dto';
 
 export type { ParticipantInfo };
 
@@ -38,6 +39,12 @@ interface ServerToClientEvents {
   'participant-joined': (data: { meetingId: string; participant: ParticipantInfo }) => void;
   'participant-left': (data: { meetingId: string; participant: ParticipantInfo }) => void;
   'participants-list': (data: { meetingId: string; participants: ParticipantInfo[] }) => void;
+  'participant-media-state': (data: {
+    meetingId: string;
+    userId: string;
+    video: boolean;
+    audio: boolean;
+  }) => void;
   offer: (data: SignalingRelayServerPayload) => void;
   answer: (data: SignalingRelayServerPayload) => void;
   'ice-candidate': (data: SignalingRelayServerPayload) => void;
@@ -47,6 +54,7 @@ interface ClientToServerEvents {
   'watch-meeting': (payload: WatchMeetingDto) => void;
   'join-room': (payload: JoinRoomDto) => void;
   'leave-room': (payload: LeaveRoomDto) => void;
+  'participant-media-state': (payload: ParticipantMediaStateDto) => void;
   offer: (payload: OfferDto) => void;
   answer: (payload: AnswerDto) => void;
   'ice-candidate': (payload: IceCandidateDto) => void;
@@ -225,6 +233,49 @@ export class SignalingGateway implements OnGatewayConnection, OnGatewayDisconnec
     );
 
     this.removeFromRoomAndBroadcast(socket);
+  }
+
+  @SubscribeMessage('participant-media-state')
+  handleParticipantMediaState(
+    @MessageBody() raw: unknown,
+    @ConnectedSocket() socket: AuthenticatedSocket,
+  ): void {
+    const user = socket.data.user;
+    this.logger.debug(
+      `Received participant-media-state from socketId=${socket.id}: ${JSON.stringify(raw)}`,
+    );
+
+    if (!user) {
+      socket.emit('error', { code: 401, message: 'Not authenticated' });
+      return;
+    }
+
+    const dto = this.validateSocketPayload(ParticipantMediaStateDto, raw, socket);
+    if (!dto) return;
+
+    const { meetingId, video, audio } = dto;
+
+    if (!this.sessionService.isParticipant(meetingId, socket.id)) {
+      socket.emit('error', { code: 403, message: 'You are not in this room' });
+      return;
+    }
+
+    const result = this.sessionService.updateMediaState(socket.id, video, audio);
+    if (!result) {
+      socket.emit('error', { code: 500, message: 'Failed to update media state' });
+      return;
+    }
+
+    this.logger.log(
+      `event=participant-media-state meetingId=${meetingId} userId=${user.id} video=${String(video)} audio=${String(audio)} ts=${new Date().toISOString()}`,
+    );
+
+    socket.to(meetingId).emit('participant-media-state', {
+      meetingId,
+      userId: user.id,
+      video,
+      audio,
+    });
   }
 
   @SubscribeMessage('offer')


### PR DESCRIPTION
## Description
- Added participant media state sync support to signaling gateway.
- New socket event 'participant-media-state' is accepted from clients, validated, user-authenticated, and broadcast to other participants in the room.
- Introduced  and  in  / .
- Updated  and  contracts for Socket.IO types.
- Added tests for the new behavior and documentation updates.

## Test plan
- [x] Run WARNING: Do not run npm and ensure all tests pass.
- [x] Run WARNING: Do not run npm and ensure media state tests pass.
- [x] Manual smoke test with Socket.IO client: join room, send media-state update, verify peers receive broadcast.
